### PR TITLE
Implement a deep "parse()" method

### DIFF
--- a/src/jsontoolkit/include/jsontoolkit/json.h
+++ b/src/jsontoolkit/include/jsontoolkit/json.h
@@ -93,6 +93,7 @@ public:
 
 private:
   auto parse_source() -> void override;
+  auto parse_deep() -> void override;
   std::variant<bool, std::nullptr_t, std::int64_t, double,
                std::shared_ptr<sourcemeta::jsontoolkit::Array>,
                std::shared_ptr<sourcemeta::jsontoolkit::Object>,

--- a/src/jsontoolkit/include/jsontoolkit/json_array.h
+++ b/src/jsontoolkit/include/jsontoolkit/json_array.h
@@ -47,6 +47,7 @@ public:
 
 private:
   auto parse_source() -> void override;
+  auto parse_deep() -> void override;
   std::vector<Wrapper> data;
 };
 } // namespace sourcemeta::jsontoolkit

--- a/src/jsontoolkit/include/jsontoolkit/json_container.h
+++ b/src/jsontoolkit/include/jsontoolkit/json_container.h
@@ -13,9 +13,12 @@ public:
   auto operator=(const Container &) -> Container & = delete;
   auto operator=(Container &&) -> Container & = delete;
 
+  auto parse() -> void;
+
 protected:
   // Child classes are expected to override parse_source().
   virtual auto parse_source() -> void = 0;
+  virtual auto parse_deep() -> void = 0;
 
   [[nodiscard]] auto is_parsed() const -> bool;
   auto parse_flat() -> void;
@@ -28,6 +31,7 @@ protected:
 private:
   const std::string_view _source;
   bool must_parse = true;
+  bool must_parse_deep = true;
 };
 } // namespace sourcemeta::jsontoolkit
 

--- a/src/jsontoolkit/include/jsontoolkit/json_object.h
+++ b/src/jsontoolkit/include/jsontoolkit/json_object.h
@@ -68,6 +68,7 @@ public:
 
 private:
   auto parse_source() -> void override;
+  auto parse_deep() -> void override;
   std::unordered_map<std::string_view, Wrapper> data;
 };
 } // namespace sourcemeta::jsontoolkit

--- a/src/jsontoolkit/include/jsontoolkit/json_string.h
+++ b/src/jsontoolkit/include/jsontoolkit/json_string.h
@@ -59,6 +59,7 @@ public:
 
 private:
   auto parse_source() -> void override;
+  auto parse_deep() -> void override;
   std::string data;
 };
 } // namespace sourcemeta::jsontoolkit

--- a/src/jsontoolkit/src/json.cc
+++ b/src/jsontoolkit/src/json.cc
@@ -43,6 +43,23 @@ sourcemeta::jsontoolkit::JSON::JSON(const std::nullptr_t)
     : Container{sourcemeta::jsontoolkit::Null::stringify(), false},
       data{std::in_place_type<std::nullptr_t>, nullptr} {}
 
+auto sourcemeta::jsontoolkit::JSON::parse_deep() -> void {
+  this->parse_flat();
+
+  // TODO: We should be able to get the type in order to
+  // implement a switch statement
+  if (this->is_string()) {
+    std::get<std::shared_ptr<sourcemeta::jsontoolkit::String>>(this->data)
+        ->parse();
+  } else if (this->is_array()) {
+    std::get<std::shared_ptr<sourcemeta::jsontoolkit::Array>>(this->data)
+        ->parse();
+  } else if (this->is_object()) {
+    std::get<std::shared_ptr<sourcemeta::jsontoolkit::Object>>(this->data)
+        ->parse();
+  }
+}
+
 auto sourcemeta::jsontoolkit::JSON::parse_source() -> void {
   const std::string_view document =
       sourcemeta::jsontoolkit::utils::trim(this->source());

--- a/src/jsontoolkit/src/json_array.cc
+++ b/src/jsontoolkit/src/json_array.cc
@@ -1,3 +1,4 @@
+#include <algorithm> // std::for_each
 #include <jsontoolkit/json.h>
 #include <jsontoolkit/json_array.h>
 #include <jsontoolkit/json_object.h>
@@ -42,6 +43,13 @@ auto sourcemeta::jsontoolkit::GenericArray<Wrapper>::size() ->
     typename sourcemeta::jsontoolkit::GenericArray<Wrapper>::size_type {
   this->parse_flat();
   return this->data.size();
+}
+
+template <typename Wrapper>
+auto sourcemeta::jsontoolkit::GenericArray<Wrapper>::parse_deep() -> void {
+  this->parse_flat();
+  std::for_each(this->data.begin(), this->data.end(),
+                [](Wrapper &element) { element.parse(); });
 }
 
 template <typename Wrapper>
@@ -252,6 +260,9 @@ sourcemeta::jsontoolkit::GenericArray<sourcemeta::jsontoolkit::JSON>::at(
 template typename sourcemeta::jsontoolkit::GenericArray<
     sourcemeta::jsontoolkit::JSON>::size_type
 sourcemeta::jsontoolkit::GenericArray<sourcemeta::jsontoolkit::JSON>::size();
+
+template void sourcemeta::jsontoolkit::GenericArray<
+    sourcemeta::jsontoolkit::JSON>::parse_deep();
 
 template void sourcemeta::jsontoolkit::GenericArray<
     sourcemeta::jsontoolkit::JSON>::parse_source();

--- a/src/jsontoolkit/src/json_container.cc
+++ b/src/jsontoolkit/src/json_container.cc
@@ -8,6 +8,15 @@ auto sourcemeta::jsontoolkit::Container::is_parsed() const -> bool {
   return !this->must_parse;
 }
 
+auto sourcemeta::jsontoolkit::Container::parse() -> void {
+  if (!this->must_parse_deep) {
+    return;
+  }
+
+  this->parse_deep();
+  this->must_parse_deep = false;
+}
+
 auto sourcemeta::jsontoolkit::Container::parse_flat() -> void {
   if (!this->must_parse) {
     return;

--- a/src/jsontoolkit/src/json_object.cc
+++ b/src/jsontoolkit/src/json_object.cc
@@ -1,3 +1,4 @@
+#include <algorithm> // std::for_each
 #include <jsontoolkit/json.h>
 #include <jsontoolkit/json_array.h>
 #include <jsontoolkit/json_object.h>
@@ -50,6 +51,15 @@ auto sourcemeta::jsontoolkit::GenericObject<Wrapper>::at(
     typename sourcemeta::jsontoolkit::GenericObject<Wrapper>::mapped_type {
   this->parse_flat();
   return std::move(this->data.at(key));
+}
+
+template <typename Wrapper>
+auto sourcemeta::jsontoolkit::GenericObject<Wrapper>::parse_deep() -> void {
+  this->parse_flat();
+  std::for_each(
+      this->data.begin(), this->data.end(),
+      [](typename std::unordered_map<std::string_view, Wrapper>::value_type
+             &p) { p.second.parse(); });
 }
 
 template <typename Wrapper>
@@ -251,6 +261,8 @@ sourcemeta::jsontoolkit::GenericObject<sourcemeta::jsontoolkit::JSON>::at(
     const typename sourcemeta::jsontoolkit::GenericObject<
         sourcemeta::jsontoolkit::JSON>::key_type &key) &&;
 
+template void sourcemeta::jsontoolkit::GenericObject<
+    sourcemeta::jsontoolkit::JSON>::parse_deep();
 template void sourcemeta::jsontoolkit::GenericObject<
     sourcemeta::jsontoolkit::JSON>::parse_source();
 

--- a/src/jsontoolkit/src/json_string.cc
+++ b/src/jsontoolkit/src/json_string.cc
@@ -44,6 +44,10 @@ static constexpr auto is_character_allowed_in_json_string(const char character)
   }
 }
 
+auto sourcemeta::jsontoolkit::String::parse_deep() -> void {
+  this->parse_flat();
+}
+
 auto sourcemeta::jsontoolkit::String::parse_source() -> void {
   const std::string_view document{
       sourcemeta::jsontoolkit::utils::trim(this->source())};

--- a/test/jsontoolkit/array_test.cc
+++ b/test/jsontoolkit/array_test.cc
@@ -44,6 +44,30 @@ TEST(Array, empty_with_comma_and_spacing) {
   EXPECT_THROW(document.size(), std::domain_error);
 }
 
+TEST(Array, parse_deep_success) {
+  sourcemeta::jsontoolkit::JSON document{"[true]"};
+  document.parse();
+  EXPECT_TRUE(document.is_array());
+  EXPECT_EQ(document.size(), 1);
+  EXPECT_EQ(document[0].to_boolean(), true);
+}
+
+TEST(Array, parse_deep_failure) {
+  sourcemeta::jsontoolkit::JSON document{"[true"};
+  EXPECT_THROW(document.parse(), std::domain_error);
+}
+
+TEST(Array, parse_deep_failure_in_item) {
+  sourcemeta::jsontoolkit::JSON document{"[tru]"};
+  EXPECT_THROW(document.parse(), std::domain_error);
+}
+
+TEST(Array, parse_is_lazy) {
+  sourcemeta::jsontoolkit::JSON document{"[x,x]"};
+  // Would throw otherwise
+  EXPECT_EQ(document.size(), 2);
+}
+
 TEST(Array, single_element) {
   sourcemeta::jsontoolkit::JSON document{"[true]"};
   EXPECT_TRUE(document.is_array());

--- a/test/jsontoolkit/json_test.cc
+++ b/test/jsontoolkit/json_test.cc
@@ -1,5 +1,7 @@
+#include <cstdint> // std::int64_t
 #include <gtest/gtest.h>
 #include <jsontoolkit/json.h>
+#include <stdexcept>   // std::domain_error
 #include <type_traits> // std::is_nothrow_move_constructible
 #include <vector>      // std::vector
 
@@ -18,6 +20,83 @@ TEST(JSON, set_boolean) {
   document = false;
   EXPECT_TRUE(document.is_boolean());
   EXPECT_EQ(document, false);
+}
+
+TEST(JSON, bool_deep_parse) {
+  sourcemeta::jsontoolkit::JSON document{"true"};
+  document.parse();
+  EXPECT_EQ(document, true);
+}
+
+TEST(JSON, bool_deep_parse_failure) {
+  sourcemeta::jsontoolkit::JSON document{"tru"};
+  EXPECT_THROW(document.parse(), std::domain_error);
+}
+
+TEST(JSON, int_deep_parse) {
+  sourcemeta::jsontoolkit::JSON document{"4"};
+  document.parse();
+  EXPECT_EQ(document, static_cast<std::int64_t>(4));
+}
+
+TEST(JSON, int_deep_parse_failure) {
+  sourcemeta::jsontoolkit::JSON document{"32,2"};
+  EXPECT_THROW(document.parse(), std::domain_error);
+}
+
+TEST(JSON, real_deep_parse) {
+  sourcemeta::jsontoolkit::JSON document{"3.14"};
+  document.parse();
+  EXPECT_EQ(document, 3.14);
+}
+
+TEST(JSON, real_deep_parse_failure) {
+  sourcemeta::jsontoolkit::JSON document{"32.2.2"};
+  EXPECT_THROW(document.parse(), std::domain_error);
+}
+
+TEST(JSON, null_deep_parse) {
+  sourcemeta::jsontoolkit::JSON document{"null"};
+  document.parse();
+  EXPECT_EQ(document, nullptr);
+}
+
+TEST(JSON, null_deep_parse_failure) {
+  sourcemeta::jsontoolkit::JSON document{"nul"};
+  EXPECT_THROW(document.parse(), std::domain_error);
+}
+
+TEST(json, string_deep_parse) {
+  sourcemeta::jsontoolkit::JSON document{"\"foo\""};
+  document.parse();
+  EXPECT_EQ(document, "foo");
+}
+
+TEST(JSON, string_deep_parse_failure) {
+  sourcemeta::jsontoolkit::JSON document{"\"foo"};
+  EXPECT_THROW(document.parse(), std::domain_error);
+}
+
+TEST(JSON, array_deep_parse) {
+  sourcemeta::jsontoolkit::JSON document{"[true,false,true]"};
+  document.parse();
+  EXPECT_EQ(document.size(), 3);
+}
+
+TEST(JSON, array_deep_parse_failure) {
+  sourcemeta::jsontoolkit::JSON document{"[true,fals,true]"};
+  EXPECT_THROW(document.parse(), std::domain_error);
+}
+
+TEST(JSON, object_deep_parse) {
+  sourcemeta::jsontoolkit::JSON document{"{\"foo\":2}"};
+  document.parse();
+  EXPECT_EQ(document.size(), 1);
+}
+
+TEST(JSON, object_deep_parse_failure) {
+  sourcemeta::jsontoolkit::JSON document{"{\"foo\":tru}"};
+  EXPECT_THROW(document.parse(), std::domain_error);
 }
 
 TEST(JSON, not_bool_equality_string) {

--- a/test/jsontoolkit/object_test.cc
+++ b/test/jsontoolkit/object_test.cc
@@ -73,6 +73,26 @@ TEST(Object, multiple_colons) {
   EXPECT_THROW(document.size(), std::domain_error);
 }
 
+TEST(Object, parse_deep_success) {
+  sourcemeta::jsontoolkit::JSON document{"{\"foo\":true}"};
+  document.parse();
+  EXPECT_TRUE(document.is_object());
+  EXPECT_EQ(document.size(), 1);
+  EXPECT_TRUE(document.contains("foo"));
+  EXPECT_TRUE(document["foo"].is_boolean());
+  EXPECT_TRUE(document["foo"].to_boolean());
+}
+
+TEST(Object, parse_deep_failure) {
+  sourcemeta::jsontoolkit::JSON document{"{\"foo\":true"};
+  EXPECT_THROW(document.parse(), std::domain_error);
+}
+
+TEST(Object, parse_deep_failure_member) {
+  sourcemeta::jsontoolkit::JSON document{"{\"foo\":tru}"};
+  EXPECT_THROW(document.parse(), std::domain_error);
+}
+
 TEST(Object, minified_one_true_boolean_element) {
   sourcemeta::jsontoolkit::JSON document{"{\"foo\":true}"};
   EXPECT_TRUE(document.is_object());

--- a/test/jsontoolkit/string_test.cc
+++ b/test/jsontoolkit/string_test.cc
@@ -71,6 +71,20 @@ TEST(String, empty_string) {
   EXPECT_EQ(document, std::string_view{""});
 }
 
+TEST(String, parse_deep_success) {
+  sourcemeta::jsontoolkit::JSON document{"\"foo\""};
+  document.parse();
+  EXPECT_TRUE(document.is_string());
+  EXPECT_EQ(document.size(), 3);
+  EXPECT_EQ(document.to_string(), "foo");
+  EXPECT_EQ(document, "foo");
+}
+
+TEST(String, parse_deep_failure) {
+  sourcemeta::jsontoolkit::JSON document{"\"foo"};
+  EXPECT_THROW(document.parse(), std::domain_error);
+}
+
 TEST(String, parse_non_empty) {
   sourcemeta::jsontoolkit::JSON document{"\"foo\""};
   EXPECT_TRUE(document.is_string());


### PR DESCRIPTION
- Rename internal parse() methods to parse_flat()
- Implement a deep "parse()" method
