### PR TITLE
Hide std::shared_ptr from type cast JSON functions

### DIFF
--- a/src/canonicalizer/src/rules/implied_array_unique_items.h
+++ b/src/canonicalizer/src/rules/implied_array_unique_items.h
@@ -18,12 +18,12 @@ public:
 
     const bool singular_by_const = schema.contains("const") &&
                                    schema["const"].is_array() &&
-                                   schema["const"].to_array()->size() <= 1;
+                                   schema["const"].to_array().size() <= 1;
 
     const bool singular_by_enum =
         schema.contains("enum") && schema["enum"].is_array() &&
-        std::all_of(schema["enum"].to_array()->cbegin(),
-                    schema["enum"].to_array()->cend(),
+        std::all_of(schema["enum"].to_array().cbegin(),
+                    schema["enum"].to_array().cend(),
                     [](const sourcemeta::jsontoolkit::JSON &element) {
                       return !element.is_array() || element.size() <= 1;
                     });

--- a/src/jsontoolkit/include/jsontoolkit/json.h
+++ b/src/jsontoolkit/include/jsontoolkit/json.h
@@ -60,9 +60,9 @@ public:
 
   // Object
   JSON(sourcemeta::jsontoolkit::Object &value);
-  auto to_object() -> std::shared_ptr<sourcemeta::jsontoolkit::Object>;
+  auto to_object() -> sourcemeta::jsontoolkit::Object &;
   [[nodiscard]] auto to_object() const
-      -> std::shared_ptr<const sourcemeta::jsontoolkit::Object>;
+      -> const sourcemeta::jsontoolkit::Object &;
   auto is_object() -> bool;
   [[nodiscard]] auto is_object() const -> bool;
   // TODO: We can also implement this for array?
@@ -78,9 +78,8 @@ public:
   // TODO: Add constructors from compatible std types like vector, array, list,
   // etc
   JSON(sourcemeta::jsontoolkit::Array &value);
-  auto to_array() -> std::shared_ptr<sourcemeta::jsontoolkit::Array>;
-  [[nodiscard]] auto to_array() const
-      -> std::shared_ptr<const sourcemeta::jsontoolkit::Array>;
+  auto to_array() -> sourcemeta::jsontoolkit::Array &;
+  [[nodiscard]] auto to_array() const -> const sourcemeta::jsontoolkit::Array &;
   auto is_array() -> bool;
   [[nodiscard]] auto is_array() const -> bool;
   auto operator[](std::size_t index) & -> JSON &;

--- a/src/jsontoolkit/include/jsontoolkit/schema.h
+++ b/src/jsontoolkit/include/jsontoolkit/schema.h
@@ -22,9 +22,8 @@ public:
       sourcemeta::jsontoolkit::JSON &;
   [[nodiscard]] auto is_object() const -> bool;
   [[nodiscard]] auto to_object() const
-      -> std::shared_ptr<const sourcemeta::jsontoolkit::Object>;
-  [[nodiscard]] auto to_array() const
-      -> std::shared_ptr<const sourcemeta::jsontoolkit::Array>;
+      -> const sourcemeta::jsontoolkit::Object &;
+  [[nodiscard]] auto to_array() const -> const sourcemeta::jsontoolkit::Array &;
 
   // https://json-schema.org/draft/2020-12/json-schema-core.html#rfc.section.8.1.1
   inline static const std::string keyword_core_schema = "$schema";

--- a/src/jsontoolkit/src/json.cc
+++ b/src/jsontoolkit/src/json.cc
@@ -230,27 +230,31 @@ auto sourcemeta::jsontoolkit::JSON::to_boolean() const -> bool {
 }
 
 auto sourcemeta::jsontoolkit::JSON::to_object()
-    -> std::shared_ptr<sourcemeta::jsontoolkit::Object> {
+    -> sourcemeta::jsontoolkit::Object & {
   this->parse_flat();
-  return std::get<std::shared_ptr<sourcemeta::jsontoolkit::Object>>(this->data);
+  return *(
+      std::get<std::shared_ptr<sourcemeta::jsontoolkit::Object>>(this->data));
 }
 
 auto sourcemeta::jsontoolkit::JSON::to_object() const
-    -> std::shared_ptr<const sourcemeta::jsontoolkit::Object> {
+    -> const sourcemeta::jsontoolkit::Object & {
   this->assert_parsed();
-  return std::get<std::shared_ptr<sourcemeta::jsontoolkit::Object>>(this->data);
+  return *(
+      std::get<std::shared_ptr<sourcemeta::jsontoolkit::Object>>(this->data));
 }
 
 auto sourcemeta::jsontoolkit::JSON::to_array()
-    -> std::shared_ptr<sourcemeta::jsontoolkit::Array> {
+    -> sourcemeta::jsontoolkit::Array & {
   this->parse_flat();
-  return std::get<std::shared_ptr<sourcemeta::jsontoolkit::Array>>(this->data);
+  return *(
+      std::get<std::shared_ptr<sourcemeta::jsontoolkit::Array>>(this->data));
 }
 
 auto sourcemeta::jsontoolkit::JSON::to_array() const
-    -> std::shared_ptr<const sourcemeta::jsontoolkit::Array> {
+    -> const sourcemeta::jsontoolkit::Array & {
   this->assert_parsed();
-  return std::get<std::shared_ptr<sourcemeta::jsontoolkit::Array>>(this->data);
+  return *(
+      std::get<std::shared_ptr<sourcemeta::jsontoolkit::Array>>(this->data));
 }
 
 auto sourcemeta::jsontoolkit::JSON::is_boolean() -> bool {

--- a/src/jsontoolkit/src/json_array.cc
+++ b/src/jsontoolkit/src/json_array.cc
@@ -332,9 +332,9 @@ auto sourcemeta::jsontoolkit::GenericArray<Wrapper>::stringify(
                           sourcemeta::jsontoolkit::JSON::token_space);
 
     if (element->is_array()) {
-      stream << element->to_array()->stringify(pretty ? indent + 1 : indent);
+      stream << element->to_array().stringify(pretty ? indent + 1 : indent);
     } else if (element->is_object()) {
-      stream << element->to_object()->stringify(pretty ? indent + 1 : indent);
+      stream << element->to_object().stringify(pretty ? indent + 1 : indent);
     } else {
       stream << element->stringify(pretty);
     }

--- a/src/jsontoolkit/src/json_object.cc
+++ b/src/jsontoolkit/src/json_object.cc
@@ -348,11 +348,10 @@ auto sourcemeta::jsontoolkit::GenericObject<Wrapper>::stringify(
     }
 
     if (pair->second.is_array()) {
-      stream << pair->second.to_array()->stringify(pretty ? indent + 1
-                                                          : indent);
+      stream << pair->second.to_array().stringify(pretty ? indent + 1 : indent);
     } else if (pair->second.is_object()) {
-      stream << pair->second.to_object()->stringify(pretty ? indent + 1
-                                                           : indent);
+      stream << pair->second.to_object().stringify(pretty ? indent + 1
+                                                          : indent);
     } else {
       stream << pair->second.stringify(pretty);
     }

--- a/src/jsontoolkit/src/schema.cc
+++ b/src/jsontoolkit/src/schema.cc
@@ -50,11 +50,11 @@ auto sourcemeta::jsontoolkit::Schema::is_object() const -> bool {
 }
 
 auto sourcemeta::jsontoolkit::Schema::to_object() const
-    -> std::shared_ptr<const sourcemeta::jsontoolkit::Object> {
+    -> const sourcemeta::jsontoolkit::Object & {
   return this->schema.to_object();
 }
 
 auto sourcemeta::jsontoolkit::Schema::to_array() const
-    -> std::shared_ptr<const sourcemeta::jsontoolkit::Array> {
+    -> const sourcemeta::jsontoolkit::Array & {
   return this->schema.to_array();
 }

--- a/test/jsontoolkit/array_test.cc
+++ b/test/jsontoolkit/array_test.cc
@@ -152,9 +152,9 @@ TEST(Array, one_level_nested_array) {
   EXPECT_EQ(document.size(), 2);
   EXPECT_TRUE(document[0].is_array());
   EXPECT_TRUE(document[1].is_boolean());
-  EXPECT_EQ(document[0].to_array()->size(), 1);
-  EXPECT_TRUE(document[0].to_array()->at(0).is_boolean());
-  EXPECT_TRUE(document[0].to_array()->at(0).to_boolean());
+  EXPECT_EQ(document[0].to_array().size(), 1);
+  EXPECT_TRUE(document[0].to_array().at(0).is_boolean());
+  EXPECT_TRUE(document[0].to_array().at(0).to_boolean());
   EXPECT_FALSE(document[1].to_boolean());
 }
 
@@ -164,9 +164,9 @@ TEST(Array, one_level_nested_array_with_padding) {
   EXPECT_EQ(document.size(), 2);
   EXPECT_TRUE(document[0].is_array());
   EXPECT_TRUE(document[1].is_boolean());
-  EXPECT_EQ(document[0].to_array()->size(), 1);
-  EXPECT_TRUE(document[0].to_array()->at(0).is_boolean());
-  EXPECT_TRUE(document[0].to_array()->at(0).to_boolean());
+  EXPECT_EQ(document[0].to_array().size(), 1);
+  EXPECT_TRUE(document[0].to_array().at(0).is_boolean());
+  EXPECT_TRUE(document[0].to_array().at(0).to_boolean());
   EXPECT_FALSE(document[1].to_boolean());
 }
 
@@ -177,13 +177,13 @@ TEST(Array, two_levels_nested_array) {
   EXPECT_TRUE(document[0].is_boolean());
   EXPECT_TRUE(document[0].to_boolean());
   EXPECT_TRUE(document[1].is_array());
-  EXPECT_EQ(document[1].to_array()->size(), 2);
-  EXPECT_TRUE(document[1].to_array()->at(0).is_boolean());
-  EXPECT_FALSE(document[1].to_array()->at(0).to_boolean());
-  EXPECT_TRUE(document[1].to_array()->at(1).is_array());
-  EXPECT_EQ(document[1].to_array()->at(1).size(), 1);
-  EXPECT_TRUE(document[1].to_array()->at(1).to_array()->at(0).is_boolean());
-  EXPECT_TRUE(document[1].to_array()->at(1).to_array()->at(0).to_boolean());
+  EXPECT_EQ(document[1].to_array().size(), 2);
+  EXPECT_TRUE(document[1].to_array().at(0).is_boolean());
+  EXPECT_FALSE(document[1].to_array().at(0).to_boolean());
+  EXPECT_TRUE(document[1].to_array().at(1).is_array());
+  EXPECT_EQ(document[1].to_array().at(1).size(), 1);
+  EXPECT_TRUE(document[1].to_array().at(1).to_array().at(0).is_boolean());
+  EXPECT_TRUE(document[1].to_array().at(1).to_array().at(0).to_boolean());
 }
 
 TEST(Array, two_levels_nested_array_clear) {
@@ -210,13 +210,13 @@ TEST(Array, two_levels_nested_array_with_padding) {
   EXPECT_TRUE(document[0].is_boolean());
   EXPECT_TRUE(document[0].to_boolean());
   EXPECT_TRUE(document[1].is_array());
-  EXPECT_EQ(document[1].to_array()->size(), 2);
-  EXPECT_TRUE(document[1].to_array()->at(0).is_boolean());
-  EXPECT_FALSE(document[1].to_array()->at(0).to_boolean());
-  EXPECT_TRUE(document[1].to_array()->at(1).is_array());
-  EXPECT_EQ(document[1].to_array()->at(1).size(), 1);
-  EXPECT_TRUE(document[1].to_array()->at(1).to_array()->at(0).is_boolean());
-  EXPECT_TRUE(document[1].to_array()->at(1).to_array()->at(0).to_boolean());
+  EXPECT_EQ(document[1].to_array().size(), 2);
+  EXPECT_TRUE(document[1].to_array().at(0).is_boolean());
+  EXPECT_FALSE(document[1].to_array().at(0).to_boolean());
+  EXPECT_TRUE(document[1].to_array().at(1).is_array());
+  EXPECT_EQ(document[1].to_array().at(1).size(), 1);
+  EXPECT_TRUE(document[1].to_array().at(1).to_array().at(0).is_boolean());
+  EXPECT_TRUE(document[1].to_array().at(1).to_array().at(0).to_boolean());
 }
 
 TEST(Array, array_of_single_string) {

--- a/test/jsontoolkit/json_test.cc
+++ b/test/jsontoolkit/json_test.cc
@@ -133,8 +133,7 @@ TEST(JSON, boolean_array_iterator) {
   sourcemeta::jsontoolkit::JSON value{"[true,false,false]"};
   std::vector<bool> result;
 
-  // TODO: Can we make range for loops nicer?
-  for (sourcemeta::jsontoolkit::JSON &element : *(value.to_array())) {
+  for (sourcemeta::jsontoolkit::JSON &element : value.to_array()) {
     result.push_back(element.to_boolean());
   }
 
@@ -150,8 +149,8 @@ TEST(JSON, boolean_array_reverse_iterator) {
 
   // TODO: Can we hide the Array type somehow?
   for (sourcemeta::jsontoolkit::Array::reverse_iterator iterator =
-           value.to_array()->rbegin();
-       iterator != value.to_array()->rend(); iterator++) {
+           value.to_array().rbegin();
+       iterator != value.to_array().rend(); iterator++) {
     result.push_back(iterator->to_boolean());
   }
 

--- a/test/jsontoolkit/object_test.cc
+++ b/test/jsontoolkit/object_test.cc
@@ -406,7 +406,7 @@ TEST(Object, const_all_of_true) {
   sourcemeta::jsontoolkit::JSON document{"{ \"foo\": 1, \"bar\": 2 }"};
   document.parse();
   const bool result =
-      std::all_of(document.to_object()->cbegin(), document.to_object()->cend(),
+      std::all_of(document.to_object().cbegin(), document.to_object().cend(),
                   [](auto pair) { return pair.second.is_integer(); });
   EXPECT_TRUE(result);
 }
@@ -415,7 +415,7 @@ TEST(Object, const_all_of_false) {
   sourcemeta::jsontoolkit::JSON document{"{ \"foo\": 1, \"bar\": \"2\" }"};
   document.parse();
   const bool result =
-      std::all_of(document.to_object()->cbegin(), document.to_object()->cend(),
+      std::all_of(document.to_object().cbegin(), document.to_object().cend(),
                   [](auto pair) { return pair.second.is_integer(); });
   EXPECT_FALSE(result);
 }
@@ -425,7 +425,7 @@ TEST(Object, const_all_of_on_const_instance) {
   source.parse();
   const sourcemeta::jsontoolkit::JSON document{std::move(source)};
   const bool result =
-      std::all_of(document.to_object()->cbegin(), document.to_object()->cend(),
+      std::all_of(document.to_object().cbegin(), document.to_object().cend(),
                   [](auto pair) { return pair.second.is_integer(); });
   EXPECT_TRUE(result);
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
