### PR TITLE
Make json_container source non-const to enable copy-assignment

### DIFF
--- a/src/jsontoolkit/include/jsontoolkit/json_container.h
+++ b/src/jsontoolkit/include/jsontoolkit/json_container.h
@@ -31,7 +31,7 @@ protected:
   auto assert_parsed() const -> void;
 
 private:
-  const std::string_view _source;
+  std::string_view _source;
   bool must_parse = true;
   bool must_parse_deep = true;
 };


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
