### PR TITLE
Call parse_flat() within parse_deep() for JSON containers

### DIFF
--- a/src/jsontoolkit/src/json_array.cc
+++ b/src/jsontoolkit/src/json_array.cc
@@ -81,7 +81,6 @@ auto sourcemeta::jsontoolkit::GenericArray<Wrapper>::clear() -> void {
 
 template <typename Wrapper>
 auto sourcemeta::jsontoolkit::GenericArray<Wrapper>::parse_deep() -> void {
-  this->parse_flat();
   std::for_each(this->data.begin(), this->data.end(),
                 [](Wrapper &element) { element.parse(); });
 }
@@ -320,7 +319,7 @@ auto sourcemeta::jsontoolkit::GenericArray<Wrapper>::operator==(
 template <typename Wrapper>
 auto sourcemeta::jsontoolkit::GenericArray<Wrapper>::stringify(
     std::size_t indent) -> std::string {
-  this->parse_deep();
+  this->parse();
   return static_cast<const sourcemeta::jsontoolkit::GenericArray<Wrapper> *>(
              this)
       ->stringify(indent);

--- a/src/jsontoolkit/src/json_container.cc
+++ b/src/jsontoolkit/src/json_container.cc
@@ -10,6 +10,9 @@ auto sourcemeta::jsontoolkit::Container::is_parsed() const -> bool {
 }
 
 auto sourcemeta::jsontoolkit::Container::parse() -> void {
+  // Deep parsing implies flat parsing
+  this->parse_flat();
+
   if (!this->must_parse_deep) {
     return;
   }

--- a/src/jsontoolkit/src/json_object.cc
+++ b/src/jsontoolkit/src/json_object.cc
@@ -95,7 +95,6 @@ auto sourcemeta::jsontoolkit::GenericObject<Wrapper>::erase(
 
 template <typename Wrapper>
 auto sourcemeta::jsontoolkit::GenericObject<Wrapper>::parse_deep() -> void {
-  this->parse_flat();
   std::for_each(
       this->data.begin(), this->data.end(),
       [](typename std::unordered_map<std::string_view, Wrapper>::value_type
@@ -316,7 +315,7 @@ auto sourcemeta::jsontoolkit::GenericObject<Wrapper>::operator==(
 template <typename Wrapper>
 auto sourcemeta::jsontoolkit::GenericObject<Wrapper>::stringify(
     std::size_t indent) -> std::string {
-  this->parse_deep();
+  this->parse();
   return static_cast<const sourcemeta::jsontoolkit::GenericObject<Wrapper> *>(
              this)
       ->stringify(indent);

--- a/src/jsontoolkit/src/json_string.cc
+++ b/src/jsontoolkit/src/json_string.cc
@@ -56,9 +56,7 @@ static constexpr auto is_character_allowed_in_json_string(const char character)
   }
 }
 
-auto sourcemeta::jsontoolkit::String::parse_deep() -> void {
-  this->parse_flat();
-}
+auto sourcemeta::jsontoolkit::String::parse_deep() -> void {}
 
 auto sourcemeta::jsontoolkit::String::parse_source() -> void {
   const std::string_view document{


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
