### PR TITLE
Do not use std::shared_ptr for managing JSON objects

### DIFF
--- a/src/jsontoolkit/include/jsontoolkit/json.h
+++ b/src/jsontoolkit/include/jsontoolkit/json.h
@@ -11,7 +11,6 @@
 
 #include <cstddef>     // std::nullptr_t
 #include <cstdint>     // std::int64_t
-#include <memory>      // std::shared_ptr
 #include <ostream>     // std::ostream
 #include <string>      // std::string
 #include <string_view> // std::string_view
@@ -151,8 +150,7 @@ private:
     string = 6
   };
   std::variant<bool, std::nullptr_t, std::int64_t, double,
-               sourcemeta::jsontoolkit::Array,
-               std::shared_ptr<sourcemeta::jsontoolkit::Object>,
+               sourcemeta::jsontoolkit::Array, sourcemeta::jsontoolkit::Object,
                sourcemeta::jsontoolkit::String>
       data;
 };

--- a/src/jsontoolkit/src/json.cc
+++ b/src/jsontoolkit/src/json.cc
@@ -3,7 +3,6 @@
 
 #include <cmath>     // std::modf
 #include <iomanip>   // std::noshowpoint
-#include <memory>    // std::make_shared
 #include <sstream>   // std::ostringstream
 #include <stdexcept> // std::domain_error, std::logic_error
 #include <string>    // std::to_string
@@ -32,8 +31,7 @@ sourcemeta::jsontoolkit::JSON::JSON(sourcemeta::jsontoolkit::Array &value)
 
 sourcemeta::jsontoolkit::JSON::JSON(sourcemeta::jsontoolkit::Object &value)
     : Container{value.source(), false},
-      data{std::in_place_type<std::shared_ptr<sourcemeta::jsontoolkit::Object>>,
-           std::make_shared<sourcemeta::jsontoolkit::Object>(value)} {}
+      data{std::in_place_type<sourcemeta::jsontoolkit::Object>, value} {}
 
 sourcemeta::jsontoolkit::JSON::JSON(sourcemeta::jsontoolkit::String &value)
     : Container{value.source(), false},
@@ -53,8 +51,7 @@ auto sourcemeta::jsontoolkit::JSON::parse_deep() -> void {
     std::get<sourcemeta::jsontoolkit::Array>(this->data).parse();
     break;
   case static_cast<std::size_t>(sourcemeta::jsontoolkit::JSON::types::object):
-    std::get<std::shared_ptr<sourcemeta::jsontoolkit::Object>>(this->data)
-        ->parse();
+    std::get<sourcemeta::jsontoolkit::Object>(this->data).parse();
     break;
   case static_cast<std::size_t>(sourcemeta::jsontoolkit::JSON::types::string):
     std::get<sourcemeta::jsontoolkit::String>(this->data).parse();
@@ -74,7 +71,7 @@ auto sourcemeta::jsontoolkit::JSON::parse_source() -> void {
     this->data = sourcemeta::jsontoolkit::Array{document};
     break;
   case sourcemeta::jsontoolkit::Object::token_begin:
-    this->data = std::make_shared<sourcemeta::jsontoolkit::Object>(document);
+    this->data = sourcemeta::jsontoolkit::Object{document};
     break;
   case sourcemeta::jsontoolkit::String::token_begin:
     this->data = sourcemeta::jsontoolkit::String{document};
@@ -172,10 +169,8 @@ auto sourcemeta::jsontoolkit::JSON::operator==(
     return std::get<sourcemeta::jsontoolkit::Array>(this->data) ==
            std::get<sourcemeta::jsontoolkit::Array>(value.data);
   case static_cast<std::size_t>(sourcemeta::jsontoolkit::JSON::types::object):
-    return *std::get<std::shared_ptr<sourcemeta::jsontoolkit::Object>>(
-               this->data) ==
-           *std::get<std::shared_ptr<sourcemeta::jsontoolkit::Object>>(
-               value.data);
+    return std::get<sourcemeta::jsontoolkit::Object>(this->data) ==
+           std::get<sourcemeta::jsontoolkit::Object>(value.data);
   case static_cast<std::size_t>(sourcemeta::jsontoolkit::JSON::types::string):
     return std::get<sourcemeta::jsontoolkit::String>(this->data) ==
            std::get<sourcemeta::jsontoolkit::String>(value.data);
@@ -219,15 +214,13 @@ auto sourcemeta::jsontoolkit::JSON::to_boolean() const -> bool {
 auto sourcemeta::jsontoolkit::JSON::to_object()
     -> sourcemeta::jsontoolkit::Object & {
   this->parse_flat();
-  return *(
-      std::get<std::shared_ptr<sourcemeta::jsontoolkit::Object>>(this->data));
+  return std::get<sourcemeta::jsontoolkit::Object>(this->data);
 }
 
 auto sourcemeta::jsontoolkit::JSON::to_object() const
     -> const sourcemeta::jsontoolkit::Object & {
   this->assert_parsed_deep();
-  return *(
-      std::get<std::shared_ptr<sourcemeta::jsontoolkit::Object>>(this->data));
+  return std::get<sourcemeta::jsontoolkit::Object>(this->data);
 }
 
 auto sourcemeta::jsontoolkit::JSON::to_array()
@@ -264,27 +257,23 @@ auto sourcemeta::jsontoolkit::JSON::is_null() const -> bool {
 
 auto sourcemeta::jsontoolkit::JSON::is_object() -> bool {
   this->parse_flat();
-  return std::holds_alternative<
-      std::shared_ptr<sourcemeta::jsontoolkit::Object>>(this->data);
+  return std::holds_alternative<sourcemeta::jsontoolkit::Object>(this->data);
 }
 
 auto sourcemeta::jsontoolkit::JSON::is_object() const -> bool {
   this->assert_parsed_flat();
-  return std::holds_alternative<
-      std::shared_ptr<sourcemeta::jsontoolkit::Object>>(this->data);
+  return std::holds_alternative<sourcemeta::jsontoolkit::Object>(this->data);
 }
 
 auto sourcemeta::jsontoolkit::JSON::contains(std::string_view key) -> bool {
   this->parse_flat();
-  return std::get<std::shared_ptr<sourcemeta::jsontoolkit::Object>>(this->data)
-      ->contains(key);
+  return std::get<sourcemeta::jsontoolkit::Object>(this->data).contains(key);
 }
 
 auto sourcemeta::jsontoolkit::JSON::contains(std::string_view key) const
     -> bool {
   this->assert_parsed_flat();
-  return std::get<std::shared_ptr<sourcemeta::jsontoolkit::Object>>(this->data)
-      ->contains(key);
+  return std::get<sourcemeta::jsontoolkit::Object>(this->data).contains(key);
 }
 
 auto sourcemeta::jsontoolkit::JSON::operator=(const bool value) &noexcept
@@ -421,29 +410,25 @@ auto sourcemeta::jsontoolkit::JSON::operator[](
 auto sourcemeta::jsontoolkit::JSON::operator[](
     std::string_view key) & -> sourcemeta::jsontoolkit::JSON & {
   this->parse_flat();
-  return std::get<std::shared_ptr<sourcemeta::jsontoolkit::Object>>(this->data)
-      ->at(key);
+  return std::get<sourcemeta::jsontoolkit::Object>(this->data).at(key);
 }
 
 auto sourcemeta::jsontoolkit::JSON::operator[](
     std::string_view key) const & -> const sourcemeta::jsontoolkit::JSON & {
   this->assert_parsed_deep();
-  return std::get<std::shared_ptr<sourcemeta::jsontoolkit::Object>>(this->data)
-      ->at(key);
+  return std::get<sourcemeta::jsontoolkit::Object>(this->data).at(key);
 }
 
 auto sourcemeta::jsontoolkit::JSON::operator[](
     std::string_view key) && -> sourcemeta::jsontoolkit::JSON {
   this->parse_flat();
   return std::move(
-      std::get<std::shared_ptr<sourcemeta::jsontoolkit::Object>>(this->data)
-          ->at(key));
+      std::get<sourcemeta::jsontoolkit::Object>(this->data).at(key));
 }
 
 auto sourcemeta::jsontoolkit::JSON::erase(std::string_view key) -> std::size_t {
   this->parse_flat();
-  return std::get<std::shared_ptr<sourcemeta::jsontoolkit::Object>>(this->data)
-      ->erase(key);
+  return std::get<sourcemeta::jsontoolkit::Object>(this->data).erase(key);
 }
 
 auto sourcemeta::jsontoolkit::JSON::size() -> std::size_t {
@@ -453,9 +438,7 @@ auto sourcemeta::jsontoolkit::JSON::size() -> std::size_t {
   case static_cast<std::size_t>(sourcemeta::jsontoolkit::JSON::types::array):
     return std::get<sourcemeta::jsontoolkit::Array>(this->data).size();
   case static_cast<std::size_t>(sourcemeta::jsontoolkit::JSON::types::object):
-    return std::get<std::shared_ptr<sourcemeta::jsontoolkit::Object>>(
-               this->data)
-        ->size();
+    return std::get<sourcemeta::jsontoolkit::Object>(this->data).size();
   case static_cast<std::size_t>(sourcemeta::jsontoolkit::JSON::types::string):
     return std::get<sourcemeta::jsontoolkit::String>(this->data).size();
   default:
@@ -470,9 +453,7 @@ auto sourcemeta::jsontoolkit::JSON::size() const -> std::size_t {
   case static_cast<std::size_t>(sourcemeta::jsontoolkit::JSON::types::array):
     return std::get<sourcemeta::jsontoolkit::Array>(this->data).size();
   case static_cast<std::size_t>(sourcemeta::jsontoolkit::JSON::types::object):
-    return std::get<std::shared_ptr<sourcemeta::jsontoolkit::Object>>(
-               this->data)
-        ->size();
+    return std::get<sourcemeta::jsontoolkit::Object>(this->data).size();
   case static_cast<std::size_t>(sourcemeta::jsontoolkit::JSON::types::string):
     return std::get<sourcemeta::jsontoolkit::String>(this->data).size();
   default:
@@ -494,9 +475,7 @@ auto sourcemeta::jsontoolkit::JSON::clear() -> void {
   case static_cast<std::size_t>(sourcemeta::jsontoolkit::JSON::types::array):
     return std::get<sourcemeta::jsontoolkit::Array>(this->data).clear();
   case static_cast<std::size_t>(sourcemeta::jsontoolkit::JSON::types::object):
-    return std::get<std::shared_ptr<sourcemeta::jsontoolkit::Object>>(
-               this->data)
-        ->clear();
+    return std::get<sourcemeta::jsontoolkit::Object>(this->data).clear();
   default:
     throw std::logic_error("Data type is not a container");
   }
@@ -574,9 +553,8 @@ auto sourcemeta::jsontoolkit::JSON::stringify(bool pretty) const
     return std::get<sourcemeta::jsontoolkit::Array>(this->data)
         .stringify(pretty ? 1 : 0);
   case static_cast<std::size_t>(sourcemeta::jsontoolkit::JSON::types::object):
-    return std::get<std::shared_ptr<sourcemeta::jsontoolkit::Object>>(
-               this->data)
-        ->stringify(pretty ? 1 : 0);
+    return std::get<sourcemeta::jsontoolkit::Object>(this->data)
+        .stringify(pretty ? 1 : 0);
   default:
     throw std::domain_error("Invalid type");
   }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
