### PR TITLE
Do not use std::string_view references on top-level JSON class

### DIFF
--- a/src/jsontoolkit/include/jsontoolkit/json.h
+++ b/src/jsontoolkit/include/jsontoolkit/json.h
@@ -31,7 +31,7 @@ public:
   // Accept string literals
   JSON(const char *document);
 
-  JSON(const std::string_view &document);
+  JSON(std::string_view document);
 
   auto operator==(const JSON &) const -> bool;
 
@@ -122,13 +122,12 @@ public:
   [[nodiscard]] auto to_string() const -> std::string;
   auto operator==(const char *) const -> bool;
   auto operator==(const std::string &) const -> bool;
-  auto operator==(const std::string_view &) const -> bool;
+  auto operator==(std::string_view) const -> bool;
   // TODO: It must be possible to set to a string that is not a quoted string
   auto operator=(const char *) &noexcept -> JSON &;
   auto operator=(const std::string &) &noexcept -> JSON &;
-  auto operator=(const std::string_view &) &noexcept -> JSON &;
+  auto operator=(std::string_view) &noexcept -> JSON &;
   auto operator=(std::string &&) &noexcept -> JSON &;
-  auto operator=(std::string_view &&) &noexcept -> JSON &;
 
   static const char token_space = ' ';
   static const char token_new_line = '\n';

--- a/src/jsontoolkit/src/json.cc
+++ b/src/jsontoolkit/src/json.cc
@@ -15,7 +15,7 @@ sourcemeta::jsontoolkit::JSON::JSON()
 sourcemeta::jsontoolkit::JSON::JSON(const char *const document)
     : Container{document, true} {}
 
-sourcemeta::jsontoolkit::JSON::JSON(const std::string_view &document)
+sourcemeta::jsontoolkit::JSON::JSON(std::string_view document)
     : Container{document, true} {}
 
 sourcemeta::jsontoolkit::JSON::JSON(const std::int64_t value)
@@ -195,8 +195,8 @@ auto sourcemeta::jsontoolkit::JSON::operator==(const std::string &value) const
   return std::get<sourcemeta::jsontoolkit::String>(this->data).value() == value;
 }
 
-auto sourcemeta::jsontoolkit::JSON::operator==(
-    const std::string_view &value) const -> bool {
+auto sourcemeta::jsontoolkit::JSON::operator==(std::string_view value) const
+    -> bool {
   this->assert_parsed_deep();
 
   if (!std::holds_alternative<sourcemeta::jsontoolkit::String>(this->data)) {
@@ -338,8 +338,7 @@ auto sourcemeta::jsontoolkit::JSON::operator=(
   return *this;
 }
 
-auto sourcemeta::jsontoolkit::JSON::operator=(
-    const std::string_view &value) &noexcept
+auto sourcemeta::jsontoolkit::JSON::operator=(std::string_view value) &noexcept
     -> sourcemeta::jsontoolkit::JSON & {
   this->reset_parse_deep();
   this->data = sourcemeta::jsontoolkit::String{value};
@@ -350,13 +349,6 @@ auto sourcemeta::jsontoolkit::JSON::operator=(std::string &&value) &noexcept
     -> sourcemeta::jsontoolkit::JSON & {
   this->reset_parse_deep();
   this->data = sourcemeta::jsontoolkit::String{std::move(value)};
-  return *this;
-}
-
-auto sourcemeta::jsontoolkit::JSON::operator=(
-    std::string_view &&value) &noexcept -> sourcemeta::jsontoolkit::JSON & {
-  this->reset_parse_deep();
-  this->data = sourcemeta::jsontoolkit::String{value};
   return *this;
 }
 


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
