### PR TITLE
Do not run clang-tidy on master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
   # other platforms.
   clang-tidy:
     runs-on: ubuntu-20.04
+    if: github.ref != 'refs/heads/master'
     steps:
       - uses: actions/checkout@v2
       - run: sudo apt-get install --yes clang-tidy


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
