### PR TITLE
Stop making use of sourcemeta::assert in canonicalizer

### DIFF
--- a/src/canonicalizer/CMakeLists.txt
+++ b/src/canonicalizer/CMakeLists.txt
@@ -6,4 +6,3 @@ target_include_directories(sourcemeta_jsonbinpack_canonicalizer PRIVATE
 target_include_directories(sourcemeta_jsonbinpack_canonicalizer INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/include")
 target_link_libraries(sourcemeta_jsonbinpack_canonicalizer PRIVATE sourcemeta::jsontoolkit)
-target_link_libraries(sourcemeta_jsonbinpack_canonicalizer PUBLIC sourcemeta::assert)

--- a/src/canonicalizer/src/bundle.cc
+++ b/src/canonicalizer/src/bundle.cc
@@ -1,8 +1,9 @@
 #include <jsonbinpack/canonicalizer/bundle.h>
 #include <jsontoolkit/schema.h>
-#include <sourcemeta/assert.h>
 
+#include <cassert>       // assert
 #include <memory>        // std::unique_ptr
+#include <stdexcept>     // std::runtime_error
 #include <string>        // std::string
 #include <tuple>         // std::tuple
 #include <unordered_set> // std::unordered_set
@@ -58,9 +59,11 @@ auto sourcemeta::jsonbinpack::canonicalizer::Bundle::apply(
     for (auto const &rule_pointer : this->rules) {
       const bool was_transformed{rule_pointer->apply(document)};
       if (was_transformed) {
-        sourcemeta::assert::CHECK(processed_rules.find(rule_pointer->name()) ==
-                                      processed_rules.end(),
-                                  "Rules must only be processed once");
+        if (processed_rules.find(rule_pointer->name()) !=
+            processed_rules.end()) {
+          throw std::runtime_error("Rules must only be processed once");
+        }
+
         processed_rules.insert(rule_pointer->name());
       }
     }
@@ -88,20 +91,20 @@ auto sourcemeta::jsonbinpack::canonicalizer::Bundle::apply(
       apply(document.at(keyword));
       break;
     case sourcemeta::jsonbinpack::canonicalizer::ApplicatorType::Array:
-      sourcemeta::assert::CHECK(document.at(keyword).is_array(),
-                                "Keyword must be an array");
+      assert(document.at(keyword).is_array());
       for (auto &element : document.at(keyword).to_array()) {
         apply(element);
       }
       break;
     case sourcemeta::jsonbinpack::canonicalizer::ApplicatorType::Object:
-      sourcemeta::assert::CHECK(document.at(keyword).is_object(),
-                                "Keyword must be an object");
+      assert(document.at(keyword).is_object());
       for (auto &pair : document.at(keyword).to_object()) {
         apply(pair.second);
       }
       break;
     default:
+      // Not reached
+      assert(false);
       break;
     }
   }

--- a/src/canonicalizer/src/canonicalizer.cc
+++ b/src/canonicalizer/src/canonicalizer.cc
@@ -1,8 +1,8 @@
+#include <cassert>
 #include <jsonbinpack/canonicalizer/bundle.h>
 #include <jsonbinpack/canonicalizer/canonicalizer.h>
 #include <jsontoolkit/json.h>
 #include <jsontoolkit/schema.h>
-#include <sourcemeta/assert.h>
 
 #include "rules/boolean_as_enum.h"
 #include "rules/boolean_schema.h"
@@ -48,9 +48,7 @@ auto sourcemeta::jsonbinpack::canonicalizer::apply(
     sourcemeta::jsontoolkit::JSON<std::string> &document)
     -> sourcemeta::jsontoolkit::JSON<std::string> & {
   document.parse();
-  sourcemeta::assert::CHECK(
-      sourcemeta::jsontoolkit::schema::is_schema(document),
-      "The input document must be a valid schema");
+  assert(sourcemeta::jsontoolkit::schema::is_schema(document));
 
   using namespace sourcemeta::jsonbinpack::canonicalizer::rules;
   sourcemeta::jsonbinpack::canonicalizer::Bundle bundle;

--- a/src/canonicalizer/src/rule.cc
+++ b/src/canonicalizer/src/rule.cc
@@ -1,5 +1,5 @@
 #include <jsonbinpack/canonicalizer/rule.h>
-#include <sourcemeta/assert.h>
+#include <stdexcept>
 #include <utility> // std::move
 
 sourcemeta::jsonbinpack::canonicalizer::Rule::Rule(std::string name)
@@ -20,11 +20,14 @@ auto sourcemeta::jsonbinpack::canonicalizer::Rule::apply(
   if (this->condition(value)) {
     this->transform(value);
     value.parse();
+
     // The condition must always be false after applying the
     // transformation in order to avoid infinite loops
-    sourcemeta::assert::CHECK(
-        !this->condition(value),
-        "A rule condition must not hold after applying the rule");
+    if (this->condition(value)) {
+      throw std::runtime_error(
+          "A rule condition must not hold after applying the rule");
+    }
+
     return true;
   }
 


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
