### PR TITLE
Move the bulk of string parsing to .parse_source()

### DIFF
--- a/src/jsontoolkit/include/jsontoolkit/json_string.h
+++ b/src/jsontoolkit/include/jsontoolkit/json_string.h
@@ -165,9 +165,7 @@ private:
     }
   }
 
-  auto parse_source() -> void override {}
-
-  auto parse_deep() -> void override {
+  auto parse_source() -> void override {
     const std::string_view document{
         sourcemeta::jsontoolkit::internal::trim(this->source())};
     sourcemeta::jsontoolkit::internal::ENSURE_PARSE(
@@ -261,6 +259,8 @@ private:
 
     this->data = std::move(value).str();
   }
+
+  auto parse_deep() -> void override {}
 
   Source data;
 };


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
