### PR TITLE
Ensure Array and Object consistency despite parsing exceptions

### DIFF
--- a/src/jsontoolkit/include/jsontoolkit/json_array.h
+++ b/src/jsontoolkit/include/jsontoolkit/json_array.h
@@ -197,6 +197,7 @@ private:
     bool expecting_value = false;
     bool is_protected_section = false;
     bool ended = false;
+    std::vector<Wrapper> result{};
 
     while (!input.eof()) {
       const char character = static_cast<char>(input.get());
@@ -271,7 +272,7 @@ private:
 
         // Push the last element, if any, into the array
         if (level == 0 && element_start_index > 0) {
-          this->data.push_back(Wrapper(Source{this->source().substr(
+          result.push_back(Wrapper(Source{this->source().substr(
               ignored + element_start_index, index - element_start_index)}));
           element_start_index = 0;
           element_cursor = 0;
@@ -292,7 +293,7 @@ private:
             element_start_index != 0, "No array value before delimiter");
         sourcemeta::jsontoolkit::internal::ENSURE_PARSE(
             element_start_index != index, "Invalid array value");
-        this->data.push_back(Wrapper(Source{this->source().substr(
+        result.push_back(Wrapper(Source{this->source().substr(
             ignored + element_start_index, index - element_start_index)}));
         element_start_index = 0;
         element_cursor = index + 1;
@@ -329,6 +330,11 @@ private:
 
     sourcemeta::jsontoolkit::internal::ENSURE_PARSE(
         level == 0 && !is_protected_section, "Unbalanced array");
+
+    // Assign the result at the very end to prevent
+    // this class from getting into an inconsistent
+    // state if parsing fails half-way through.
+    this->data = std::move(result);
   }
 
   // TODO: Delete this function

--- a/src/jsontoolkit/include/jsontoolkit/json_object.h
+++ b/src/jsontoolkit/include/jsontoolkit/json_object.h
@@ -178,6 +178,7 @@ private:
     bool is_string = false;
     bool expecting_value_end = false;
     bool expecting_element_after_delimiter = false;
+    std::map<Source, Wrapper> result{};
 
     for (std::string_view::size_type index = 1; index < document.size();
          index++) {
@@ -238,11 +239,10 @@ private:
         // We have a key and the start of the value, but the object ended
         if (key_start_index != 0 && key_end_index != 0 &&
             value_start_index != 0) {
-          this->data.insert(
-              {Source{document.substr(key_start_index,
-                                      key_end_index - key_start_index)},
-               Wrapper{Source{document.substr(value_start_index,
-                                              index - value_start_index)}}});
+          result.insert({Source{document.substr(
+                             key_start_index, key_end_index - key_start_index)},
+                         Wrapper{Source{document.substr(
+                             value_start_index, index - value_start_index)}}});
           value_start_index = 0;
           key_start_index = 0;
           key_end_index = 0;
@@ -264,11 +264,10 @@ private:
         // We have a key and the start of the value, but we found a comma
         if (key_start_index != 0 && key_end_index != 0 &&
             value_start_index != 0) {
-          this->data.insert(
-              {Source{document.substr(key_start_index,
-                                      key_end_index - key_start_index)},
-               Wrapper{Source{document.substr(value_start_index,
-                                              index - value_start_index)}}});
+          result.insert({Source{document.substr(
+                             key_start_index, key_end_index - key_start_index)},
+                         Wrapper{Source{document.substr(
+                             value_start_index, index - value_start_index)}}});
           value_start_index = 0;
           key_start_index = 0;
           key_end_index = 0;
@@ -322,6 +321,11 @@ private:
 
     sourcemeta::jsontoolkit::internal::ENSURE_PARSE(
         array_level == 0 && !is_string && level == 0, "Unbalanced object");
+
+    // Assign the result at the very end to prevent
+    // this class from getting into an inconsistent
+    // state if parsing fails half-way through.
+    this->data = std::move(result);
   }
 
   auto parse_deep() -> void override {


### PR DESCRIPTION
Fixes: https://github.com/sourcemeta/jsonbinpack/issues/330
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
