### PR TITLE
Fix "type" string check in BooleanAsEnum canonicalizer rule

### DIFF
--- a/src/canonicalizer/rules/boolean_as_enum.h
+++ b/src/canonicalizer/rules/boolean_as_enum.h
@@ -14,6 +14,8 @@ public:
                "https://json-schema.org/draft/2020-12/vocab/validation") &&
            sourcemeta::jsontoolkit::is_object(schema) &&
            sourcemeta::jsontoolkit::defines(schema, "type") &&
+           sourcemeta::jsontoolkit::is_string(
+               sourcemeta::jsontoolkit::at(schema, "type")) &&
            sourcemeta::jsontoolkit::to_string(
                sourcemeta::jsontoolkit::at(schema, "type")) == "boolean" &&
            !sourcemeta::jsontoolkit::defines(schema, "enum");


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
