### PR TITLE
Avoid unused named variables in canonicalizer rules

### DIFF
--- a/src/canonicalizer/rules/boolean_schema.h
+++ b/src/canonicalizer/rules/boolean_schema.h
@@ -4,11 +4,10 @@ class BooleanSchema final : public sourcemeta::alterschema::Rule {
 public:
   BooleanSchema() : Rule("boolean_schema"){};
 
-  [[nodiscard]] auto
-  condition(const sourcemeta::jsontoolkit::Value &schema,
-            const std::string &dialect,
-            const std::unordered_map<std::string, bool> &vocabularies,
-            const std::size_t) const -> bool override {
+  [[nodiscard]] auto condition(const sourcemeta::jsontoolkit::Value &schema,
+                               const std::string &,
+                               const std::unordered_map<std::string, bool> &,
+                               const std::size_t) const -> bool override {
     return sourcemeta::jsontoolkit::is_boolean(schema);
   }
 

--- a/src/canonicalizer/rules/content_schema_without_content_media_type.h
+++ b/src/canonicalizer/rules/content_schema_without_content_media_type.h
@@ -19,7 +19,7 @@ public:
            !sourcemeta::jsontoolkit::defines(schema, "contentMediaType");
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     sourcemeta::jsontoolkit::erase(value, "contentSchema");
   }

--- a/src/canonicalizer/rules/drop_non_array_keywords_applicator.h
+++ b/src/canonicalizer/rules/drop_non_array_keywords_applicator.h
@@ -24,7 +24,7 @@ public:
                                                 this->BLACKLIST_APPLICATOR);
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     sourcemeta::jsontoolkit::erase_many(value, this->BLACKLIST_APPLICATOR);
   }

--- a/src/canonicalizer/rules/drop_non_array_keywords_content.h
+++ b/src/canonicalizer/rules/drop_non_array_keywords_content.h
@@ -23,7 +23,7 @@ public:
                                                 this->BLACKLIST_CONTENT);
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     sourcemeta::jsontoolkit::erase_many(value, this->BLACKLIST_CONTENT);
   }

--- a/src/canonicalizer/rules/drop_non_array_keywords_format.h
+++ b/src/canonicalizer/rules/drop_non_array_keywords_format.h
@@ -23,7 +23,7 @@ public:
            sourcemeta::jsontoolkit::defines_any(schema, this->BLACKLIST_FORMAT);
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     sourcemeta::jsontoolkit::erase_many(value, this->BLACKLIST_FORMAT);
   }

--- a/src/canonicalizer/rules/drop_non_array_keywords_unevaluated.h
+++ b/src/canonicalizer/rules/drop_non_array_keywords_unevaluated.h
@@ -24,7 +24,7 @@ public:
                                                 this->BLACKLIST_UNEVALUATED);
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     sourcemeta::jsontoolkit::erase_many(value, this->BLACKLIST_UNEVALUATED);
   }

--- a/src/canonicalizer/rules/drop_non_array_keywords_validation.h
+++ b/src/canonicalizer/rules/drop_non_array_keywords_validation.h
@@ -22,7 +22,7 @@ public:
                                                 this->BLACKLIST_VALIDATION);
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     sourcemeta::jsontoolkit::erase_many(value, this->BLACKLIST_VALIDATION);
   }

--- a/src/canonicalizer/rules/drop_non_boolean_keywords_applicator.h
+++ b/src/canonicalizer/rules/drop_non_boolean_keywords_applicator.h
@@ -18,7 +18,7 @@ public:
                                                 this->BLACKLIST_APPLICATOR);
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     sourcemeta::jsontoolkit::erase_many(value, this->BLACKLIST_APPLICATOR);
   }

--- a/src/canonicalizer/rules/drop_non_boolean_keywords_content.h
+++ b/src/canonicalizer/rules/drop_non_boolean_keywords_content.h
@@ -17,7 +17,7 @@ public:
                                                 this->BLACKLIST_CONTENT);
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     sourcemeta::jsontoolkit::erase_many(value, this->BLACKLIST_CONTENT);
   }

--- a/src/canonicalizer/rules/drop_non_boolean_keywords_format.h
+++ b/src/canonicalizer/rules/drop_non_boolean_keywords_format.h
@@ -18,7 +18,7 @@ public:
            sourcemeta::jsontoolkit::defines_any(schema, this->BLACKLIST_FORMAT);
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     sourcemeta::jsontoolkit::erase_many(value, this->BLACKLIST_FORMAT);
   }

--- a/src/canonicalizer/rules/drop_non_boolean_keywords_unevaluated.h
+++ b/src/canonicalizer/rules/drop_non_boolean_keywords_unevaluated.h
@@ -18,7 +18,7 @@ public:
                                                 this->BLACKLIST_UNEVALUATED);
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     sourcemeta::jsontoolkit::erase_many(value, this->BLACKLIST_UNEVALUATED);
   }

--- a/src/canonicalizer/rules/drop_non_boolean_keywords_validation.h
+++ b/src/canonicalizer/rules/drop_non_boolean_keywords_validation.h
@@ -18,7 +18,7 @@ public:
                                                 this->BLACKLIST_VALIDATION);
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     sourcemeta::jsontoolkit::erase_many(value, this->BLACKLIST_VALIDATION);
   }

--- a/src/canonicalizer/rules/drop_non_null_keywords_applicator.h
+++ b/src/canonicalizer/rules/drop_non_null_keywords_applicator.h
@@ -17,7 +17,7 @@ public:
                                                 this->BLACKLIST_APPLICATOR);
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     sourcemeta::jsontoolkit::erase_many(value, this->BLACKLIST_APPLICATOR);
   }

--- a/src/canonicalizer/rules/drop_non_null_keywords_content.h
+++ b/src/canonicalizer/rules/drop_non_null_keywords_content.h
@@ -16,7 +16,7 @@ public:
                                                 this->BLACKLIST_CONTENT);
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     sourcemeta::jsontoolkit::erase_many(value, this->BLACKLIST_CONTENT);
   }

--- a/src/canonicalizer/rules/drop_non_null_keywords_format.h
+++ b/src/canonicalizer/rules/drop_non_null_keywords_format.h
@@ -17,7 +17,7 @@ public:
            sourcemeta::jsontoolkit::defines_any(schema, this->BLACKLIST_FORMAT);
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     sourcemeta::jsontoolkit::erase_many(value, this->BLACKLIST_FORMAT);
   }

--- a/src/canonicalizer/rules/drop_non_null_keywords_unevaluated.h
+++ b/src/canonicalizer/rules/drop_non_null_keywords_unevaluated.h
@@ -18,7 +18,7 @@ public:
                                                 this->BLACKLIST_UNEVALUATED);
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     sourcemeta::jsontoolkit::erase_many(value, this->BLACKLIST_UNEVALUATED);
   }

--- a/src/canonicalizer/rules/drop_non_null_keywords_validation.h
+++ b/src/canonicalizer/rules/drop_non_null_keywords_validation.h
@@ -17,7 +17,7 @@ public:
                                                 this->BLACKLIST_VALIDATION);
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     sourcemeta::jsontoolkit::erase_many(value, this->BLACKLIST_VALIDATION);
   }

--- a/src/canonicalizer/rules/drop_non_numeric_keywords_applicator.h
+++ b/src/canonicalizer/rules/drop_non_numeric_keywords_applicator.h
@@ -26,7 +26,7 @@ public:
                                                 this->BLACKLIST_APPLICATOR);
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     sourcemeta::jsontoolkit::erase_many(value, this->BLACKLIST_APPLICATOR);
   }

--- a/src/canonicalizer/rules/drop_non_numeric_keywords_content.h
+++ b/src/canonicalizer/rules/drop_non_numeric_keywords_content.h
@@ -25,7 +25,7 @@ public:
                                                 this->BLACKLIST_CONTENT);
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     sourcemeta::jsontoolkit::erase_many(value, this->BLACKLIST_CONTENT);
   }

--- a/src/canonicalizer/rules/drop_non_numeric_keywords_format.h
+++ b/src/canonicalizer/rules/drop_non_numeric_keywords_format.h
@@ -26,7 +26,7 @@ public:
            sourcemeta::jsontoolkit::defines_any(schema, this->BLACKLIST_FORMAT);
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     sourcemeta::jsontoolkit::erase_many(value, this->BLACKLIST_FORMAT);
   }

--- a/src/canonicalizer/rules/drop_non_numeric_keywords_unevaluated.h
+++ b/src/canonicalizer/rules/drop_non_numeric_keywords_unevaluated.h
@@ -26,7 +26,7 @@ public:
                                                 this->BLACKLIST_UNEVALUATED);
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     sourcemeta::jsontoolkit::erase_many(value, this->BLACKLIST_UNEVALUATED);
   }

--- a/src/canonicalizer/rules/drop_non_numeric_keywords_validation.h
+++ b/src/canonicalizer/rules/drop_non_numeric_keywords_validation.h
@@ -24,7 +24,7 @@ public:
                                                 this->BLACKLIST_VALIDATION);
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     sourcemeta::jsontoolkit::erase_many(value, this->BLACKLIST_VALIDATION);
   }

--- a/src/canonicalizer/rules/drop_non_object_keywords_applicator.h
+++ b/src/canonicalizer/rules/drop_non_object_keywords_applicator.h
@@ -24,7 +24,7 @@ public:
                                                 this->BLACKLIST_APPLICATOR);
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     sourcemeta::jsontoolkit::erase_many(value, this->BLACKLIST_APPLICATOR);
   }

--- a/src/canonicalizer/rules/drop_non_object_keywords_content.h
+++ b/src/canonicalizer/rules/drop_non_object_keywords_content.h
@@ -23,7 +23,7 @@ public:
                                                 this->BLACKLIST_CONTENT);
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     sourcemeta::jsontoolkit::erase_many(value, this->BLACKLIST_CONTENT);
   }

--- a/src/canonicalizer/rules/drop_non_object_keywords_format.h
+++ b/src/canonicalizer/rules/drop_non_object_keywords_format.h
@@ -23,7 +23,7 @@ public:
            sourcemeta::jsontoolkit::defines_any(schema, this->BLACKLIST_FORMAT);
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     sourcemeta::jsontoolkit::erase_many(value, this->BLACKLIST_FORMAT);
   }

--- a/src/canonicalizer/rules/drop_non_object_keywords_unevaluated.h
+++ b/src/canonicalizer/rules/drop_non_object_keywords_unevaluated.h
@@ -24,7 +24,7 @@ public:
                                                 this->BLACKLIST_UNEVALUATED);
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     sourcemeta::jsontoolkit::erase_many(value, this->BLACKLIST_UNEVALUATED);
   }

--- a/src/canonicalizer/rules/drop_non_object_keywords_validation.h
+++ b/src/canonicalizer/rules/drop_non_object_keywords_validation.h
@@ -22,7 +22,7 @@ public:
                                                 this->BLACKLIST_VALIDATION);
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     sourcemeta::jsontoolkit::erase_many(value, this->BLACKLIST_VALIDATION);
   }

--- a/src/canonicalizer/rules/drop_non_string_keywords_applicator.h
+++ b/src/canonicalizer/rules/drop_non_string_keywords_applicator.h
@@ -24,7 +24,7 @@ public:
                                                 this->BLACKLIST_APPLICATOR);
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     sourcemeta::jsontoolkit::erase_many(value, this->BLACKLIST_APPLICATOR);
   }

--- a/src/canonicalizer/rules/drop_non_string_keywords_unevaluated.h
+++ b/src/canonicalizer/rules/drop_non_string_keywords_unevaluated.h
@@ -24,7 +24,7 @@ public:
                                                 this->BLACKLIST_UNEVALUATED);
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     sourcemeta::jsontoolkit::erase_many(value, this->BLACKLIST_UNEVALUATED);
   }

--- a/src/canonicalizer/rules/drop_non_string_keywords_validation.h
+++ b/src/canonicalizer/rules/drop_non_string_keywords_validation.h
@@ -22,7 +22,7 @@ public:
                                                 this->BLACKLIST_VALIDATION);
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     sourcemeta::jsontoolkit::erase_many(value, this->BLACKLIST_VALIDATION);
   }

--- a/src/canonicalizer/rules/duplicate_allof_branches.h
+++ b/src/canonicalizer/rules/duplicate_allof_branches.h
@@ -18,7 +18,7 @@ public:
            is_unique(sourcemeta::jsontoolkit::at(schema, "allOf"));
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     auto &collection{sourcemeta::jsontoolkit::at(value, "allOf")};
     std::sort(sourcemeta::jsontoolkit::begin_array(collection),

--- a/src/canonicalizer/rules/duplicate_anyof_branches.h
+++ b/src/canonicalizer/rules/duplicate_anyof_branches.h
@@ -18,7 +18,7 @@ public:
            is_unique(sourcemeta::jsontoolkit::at(schema, "anyOf"));
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     auto &collection{sourcemeta::jsontoolkit::at(value, "anyOf")};
     std::sort(sourcemeta::jsontoolkit::begin_array(collection),

--- a/src/canonicalizer/rules/duplicate_enum_values.h
+++ b/src/canonicalizer/rules/duplicate_enum_values.h
@@ -18,7 +18,7 @@ public:
            is_unique(sourcemeta::jsontoolkit::at(schema, "enum"));
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     auto &collection{sourcemeta::jsontoolkit::at(value, "enum")};
     std::sort(sourcemeta::jsontoolkit::begin_array(collection),

--- a/src/canonicalizer/rules/duplicate_oneof_branches.h
+++ b/src/canonicalizer/rules/duplicate_oneof_branches.h
@@ -18,7 +18,7 @@ public:
            is_unique(sourcemeta::jsontoolkit::at(schema, "oneOf"));
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     auto &collection{sourcemeta::jsontoolkit::at(value, "oneOf")};
     std::sort(sourcemeta::jsontoolkit::begin_array(collection),

--- a/src/canonicalizer/rules/empty_dependent_required.h
+++ b/src/canonicalizer/rules/empty_dependent_required.h
@@ -19,7 +19,7 @@ public:
                sourcemeta::jsontoolkit::at(schema, "dependentRequired"));
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     sourcemeta::jsontoolkit::erase(value, "dependentRequired");
   }

--- a/src/canonicalizer/rules/empty_pattern_properties.h
+++ b/src/canonicalizer/rules/empty_pattern_properties.h
@@ -19,7 +19,7 @@ public:
                sourcemeta::jsontoolkit::at(schema, "patternProperties"));
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     sourcemeta::jsontoolkit::erase(value, "patternProperties");
   }

--- a/src/canonicalizer/rules/exclusive_maximum_and_maximum.h
+++ b/src/canonicalizer/rules/exclusive_maximum_and_maximum.h
@@ -20,7 +20,7 @@ public:
                sourcemeta::jsontoolkit::at(schema, "exclusiveMaximum"));
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     const bool maximum_less_than_exclusive_maximum{
         sourcemeta::jsontoolkit::compare(

--- a/src/canonicalizer/rules/exclusive_minimum_and_minimum.h
+++ b/src/canonicalizer/rules/exclusive_minimum_and_minimum.h
@@ -20,7 +20,7 @@ public:
                sourcemeta::jsontoolkit::at(schema, "exclusiveMinimum"));
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     const bool exclusive_minimum_less_than_minimum{
         sourcemeta::jsontoolkit::compare(

--- a/src/canonicalizer/rules/if_without_then_else.h
+++ b/src/canonicalizer/rules/if_without_then_else.h
@@ -21,7 +21,7 @@ public:
            !sourcemeta::jsontoolkit::defines(schema, "else");
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     sourcemeta::jsontoolkit::erase(value, "if");
   }

--- a/src/canonicalizer/rules/implied_array_unique_items.h
+++ b/src/canonicalizer/rules/implied_array_unique_items.h
@@ -59,7 +59,7 @@ public:
            (singular_by_max_items || singular_by_const || singular_by_enum);
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     sourcemeta::jsontoolkit::erase(value, "uniqueItems");
   }

--- a/src/canonicalizer/rules/max_contains_without_contains.h
+++ b/src/canonicalizer/rules/max_contains_without_contains.h
@@ -18,7 +18,7 @@ public:
            !sourcemeta::jsontoolkit::defines(schema, "contains");
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     sourcemeta::jsontoolkit::erase(value, "maxContains");
   }

--- a/src/canonicalizer/rules/min_contains_without_contains.h
+++ b/src/canonicalizer/rules/min_contains_without_contains.h
@@ -18,7 +18,7 @@ public:
            !sourcemeta::jsontoolkit::defines(schema, "contains");
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     sourcemeta::jsontoolkit::erase(value, "minContains");
   }

--- a/src/canonicalizer/rules/then_else_without_if.h
+++ b/src/canonicalizer/rules/then_else_without_if.h
@@ -17,7 +17,7 @@ public:
            sourcemeta::jsontoolkit::defines(schema, "else");
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     sourcemeta::jsontoolkit::erase(value, "then");
     sourcemeta::jsontoolkit::erase(value, "else");

--- a/src/canonicalizer/rules/unsatisfiable_max_contains.h
+++ b/src/canonicalizer/rules/unsatisfiable_max_contains.h
@@ -24,7 +24,7 @@ public:
                    sourcemeta::jsontoolkit::at(schema, "maxItems"));
   }
 
-  auto transform(sourcemeta::jsontoolkit::JSON &document,
+  auto transform(sourcemeta::jsontoolkit::JSON &,
                  sourcemeta::jsontoolkit::Value &value) const -> void override {
     sourcemeta::jsontoolkit::erase(value, "maxContains");
   }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
