### PR TITLE
Stress test Base-128 varint encoder/decode with max `uint64_t`

### DIFF
--- a/src/decoder/include/jsonbinpack/decoder/basic_decoder.h
+++ b/src/decoder/include/jsonbinpack/decoder/basic_decoder.h
@@ -24,11 +24,11 @@ public:
   }
 
   inline auto get_varint() -> std::uint64_t {
-    return decoder::varint<std::int64_t>(this->stream);
+    return decoder::varint(this->stream);
   }
 
   inline auto get_varint_zigzag() -> std::int64_t {
-    const std::uint64_t value = decoder::varint<std::int64_t>(this->stream);
+    const std::uint64_t value = decoder::varint(this->stream);
     return decoder::zigzag(value);
   }
 

--- a/src/decoder/include/jsonbinpack/decoder/varint.h
+++ b/src/decoder/include/jsonbinpack/decoder/varint.h
@@ -1,10 +1,9 @@
 #ifndef SOURCEMETA_JSONBINPACK_DECODER_VARINT_H_
 #define SOURCEMETA_JSONBINPACK_DECODER_VARINT_H_
 
-#include <cassert>     // assert
-#include <cstdint>     // std::uint8_t
-#include <istream>     // std::basic_istream
-#include <type_traits> // std::enable_if_t, std::is_integral_v
+#include <cassert> // assert
+#include <cstdint> // std::uint8_t, std::uint64_t
+#include <istream> // std::basic_istream
 
 static const std::uint8_t LEAST_SIGNIFICANT_BITS{0b01111111};
 static const std::uint8_t MOST_SIGNIFICANT_BIT{0b10000000};
@@ -12,20 +11,16 @@ static const std::uint8_t SHIFT{7};
 
 namespace sourcemeta::jsonbinpack::decoder {
 
-// The SFINAE constrain would allow us to further overload this
-// class for big integers in the future.
-template <typename T, typename CharT, typename Traits,
-          typename = std::enable_if_t<std::is_integral_v<T>>>
-auto varint(std::basic_istream<CharT, Traits> &stream) -> T {
-  T result{0};
+template <typename CharT, typename Traits>
+auto varint(std::basic_istream<CharT, Traits> &stream) -> std::uint64_t {
+  std::uint64_t result{0};
   std::size_t cursor{0};
   while (true) {
-    const auto byte{stream.get()};
+    const std::uint8_t byte{static_cast<std::uint8_t>(stream.get())};
     assert(!stream.eof());
-    // If we don't cast to unsigned, then we risk getting the
-    // two's complement for large enough bytes.
-    result += static_cast<unsigned int>((byte & LEAST_SIGNIFICANT_BITS)
-                                        << SHIFT * cursor);
+    const std::uint64_t value{
+        static_cast<std::uint64_t>(byte & LEAST_SIGNIFICANT_BITS)};
+    result += static_cast<std::uint64_t>(value << SHIFT * cursor);
     cursor += 1;
     if ((byte & MOST_SIGNIFICANT_BIT) == 0) {
       break;

--- a/src/encoder/include/jsonbinpack/encoder/varint.h
+++ b/src/encoder/include/jsonbinpack/encoder/varint.h
@@ -1,10 +1,8 @@
 #ifndef SOURCEMETA_JSONBINPACK_ENCODER_VARINT_H_
 #define SOURCEMETA_JSONBINPACK_ENCODER_VARINT_H_
 
-#include <cassert>     // assert
-#include <cstdint>     // std::uint8_t
-#include <ostream>     // std::basic_ostream
-#include <type_traits> // std::enable_if_t, std::is_integral_v
+#include <cstdint> // std::uint8_t, std::uint64_t
+#include <ostream> // std::basic_ostream
 
 static const std::uint8_t LEAST_SIGNIFICANT_BITS{0b01111111};
 static const std::uint8_t MOST_SIGNIFICANT_BIT{0b10000000};
@@ -12,15 +10,11 @@ static const std::uint8_t SHIFT{7};
 
 namespace sourcemeta::jsonbinpack::encoder {
 
-// The SFINAE constrain would allow us to further overload this
-// class for big integers in the future.
-template <typename T, typename CharT, typename Traits,
-          typename = std::enable_if_t<std::is_integral_v<T>>>
-auto varint(std::basic_ostream<CharT, Traits> &stream, const T value)
-    -> std::basic_ostream<CharT, Traits> & {
-  // This encoder does not handle negative integers. Use ZigZag first instead.
-  assert(value >= 0);
-  T accumulator = value;
+// This encoder does not handle negative integers. Use ZigZag first instead.
+template <typename CharT, typename Traits>
+auto varint(std::basic_ostream<CharT, Traits> &stream,
+            const std::uint64_t value) -> std::basic_ostream<CharT, Traits> & {
+  std::uint64_t accumulator = value;
 
   while (accumulator > LEAST_SIGNIFICANT_BITS) {
     stream.put(static_cast<std::uint8_t>(

--- a/test/decoder/decode_varint_test.cc
+++ b/test/decoder/decode_varint_test.cc
@@ -3,32 +3,41 @@
 #include <jsontoolkit/json.h>
 
 #include <gtest/gtest.h>
+#include <limits> // std::numeric_limits
 
 TEST(Decoder, varint_0x01) {
   InputByteStream<char> stream{0x01};
-  EXPECT_EQ(sourcemeta::jsonbinpack::decoder::varint<std::uint64_t>(stream), 1);
+  EXPECT_EQ(sourcemeta::jsonbinpack::decoder::varint(stream), 1);
 }
 
 TEST(Decoder, varint_0x17) {
   InputByteStream<char> stream{0x17};
-  EXPECT_EQ(sourcemeta::jsonbinpack::decoder::varint<std::uint64_t>(stream),
-            23);
+  EXPECT_EQ(sourcemeta::jsonbinpack::decoder::varint(stream), 23);
 }
 
 TEST(Decoder, varint_0xac_0x02) {
   InputByteStream<char> stream{{0xac, 0x02}};
-  EXPECT_EQ(sourcemeta::jsonbinpack::decoder::varint<std::uint64_t>(stream),
-            300);
+  EXPECT_EQ(sourcemeta::jsonbinpack::decoder::varint(stream), 300);
 }
 
 TEST(Decoder, varint_0xdf_0x89_0x03) {
   InputByteStream<char> stream{{0xdf, 0x89, 0x03}};
-  EXPECT_EQ(sourcemeta::jsonbinpack::decoder::varint<std::uint64_t>(stream),
-            50399);
+  EXPECT_EQ(sourcemeta::jsonbinpack::decoder::varint(stream), 50399);
 }
 
 TEST(Decoder, varint_0xfe_0xff_0xff_0xff_0x0f) {
   InputByteStream<char> stream{{0xfe, 0xff, 0xff, 0xff, 0x0f}};
-  EXPECT_EQ(sourcemeta::jsonbinpack::decoder::varint<std::uint64_t>(stream),
-            4294967294);
+  const std::uint64_t result{sourcemeta::jsonbinpack::decoder::varint(stream)};
+  const std::uint64_t expected{4294967294};
+  EXPECT_EQ(result, expected);
+}
+
+TEST(Decoder, varint_uint64_max) {
+  // In Base-128: (1)1111111 (1)1111111 (1)1111111 (1)1111111
+  // (1)1111111 (1)1111111 (1)1111111 (1)1111111 (1)1111111 (0)0000001
+  InputByteStream<char> stream{
+      {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01}};
+  const std::uint64_t result{sourcemeta::jsonbinpack::decoder::varint(stream)};
+  const std::uint64_t expected{18446744073709551615U};
+  EXPECT_EQ(result, expected);
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
