### PR TITLE
Mark certain encoder/decoder utility methods as `noexcept`

### DIFF
--- a/src/decoder/include/jsonbinpack/decoder/basic_decoder.h
+++ b/src/decoder/include/jsonbinpack/decoder/basic_decoder.h
@@ -32,7 +32,7 @@ public:
     return decoder::zigzag(value);
   }
 
-  inline auto has_more_data() const -> bool {
+  inline auto has_more_data() const noexcept -> bool {
     // A way to check if the stream is empty without using `.peek()`,
     // which throws given we set exceptions on the EOF bit.
     return this->stream.rdbuf()->in_avail() > 0;

--- a/src/encoder/include/jsonbinpack/encoder/basic_encoder.h
+++ b/src/encoder/include/jsonbinpack/encoder/basic_encoder.h
@@ -21,7 +21,9 @@ public:
                             std::ios_base::eofbit);
   }
 
-  inline auto position() const -> std::uint64_t { return this->stream.tellp(); }
+  inline auto position() const noexcept -> std::uint64_t {
+    return this->stream.tellp();
+  }
 
   inline auto put_byte(const std::uint8_t byte) -> void {
     this->stream.put(static_cast<std::int8_t>(byte));


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
