### PR TITLE
Make context's `remove_oldest()` method private

### DIFF
--- a/src/encoder/include/jsonbinpack/encoder/context.h
+++ b/src/encoder/include/jsonbinpack/encoder/context.h
@@ -58,17 +58,6 @@ public:
     }
   }
 
-  auto remove_oldest() -> void {
-    assert(!this->strings.empty());
-    // std::map are by definition ordered by key,
-    // so the begin iterator points to the entry
-    // with the lowest offset, a.k.a. the oldest.
-    const auto iterator{std::cbegin(this->offsets)};
-    this->strings.erase(iterator->second);
-    this->byte_size -= iterator->second.size();
-    this->offsets.erase(iterator);
-  }
-
   auto has(const std::basic_string<CharT> &value) const -> bool {
     return this->strings.contains(value);
   }
@@ -80,6 +69,17 @@ public:
   }
 
 private:
+  auto remove_oldest() -> void {
+    assert(!this->strings.empty());
+    // std::map are by definition ordered by key,
+    // so the begin iterator points to the entry
+    // with the lowest offset, a.k.a. the oldest.
+    const auto iterator{std::cbegin(this->offsets)};
+    this->strings.erase(iterator->second);
+    this->byte_size -= iterator->second.size();
+    this->offsets.erase(iterator);
+  }
+
   std::map<std::basic_string<CharT>, std::uint64_t> strings;
   // A mirror of the above map to be able to sort by offset.
   // While this means we need 2x the amount of memory to keep track

--- a/test/encoder/context_test.cc
+++ b/test/encoder/context_test.cc
@@ -54,35 +54,6 @@ TEST(Encoder, context_not_record_too_big) {
   EXPECT_FALSE(context.has(too_big));
 }
 
-TEST(Encoder, context_remove_oldest) {
-  sourcemeta::jsonbinpack::encoder::Context<char> context;
-  context.record("foo", 10);
-  context.record("bar", 3);
-  context.record("baz", 7);
-
-  EXPECT_TRUE(context.has("foo"));
-  EXPECT_TRUE(context.has("bar"));
-  EXPECT_TRUE(context.has("baz"));
-
-  context.remove_oldest();
-
-  EXPECT_TRUE(context.has("foo"));
-  EXPECT_FALSE(context.has("bar"));
-  EXPECT_TRUE(context.has("baz"));
-
-  context.remove_oldest();
-
-  EXPECT_TRUE(context.has("foo"));
-  EXPECT_FALSE(context.has("bar"));
-  EXPECT_FALSE(context.has("baz"));
-
-  context.remove_oldest();
-
-  EXPECT_FALSE(context.has("foo"));
-  EXPECT_FALSE(context.has("bar"));
-  EXPECT_FALSE(context.has("baz"));
-}
-
 TEST(Encoder, context_is_a_circular_buffer) {
   const auto length{5000000};
   const std::string string_1(length, 'u');


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
