### PR TITLE
Make the Encoding variant `nothrow` move constructible

### DIFF
--- a/src/options/include/jsonbinpack/options/options.h
+++ b/src/options/include/jsonbinpack/options/options.h
@@ -3,9 +3,12 @@
 
 #include <jsontoolkit/json.h>
 
-#include <cstdint> // std::int64_t, std::uint64_t
-#include <variant> // std::variant
-#include <vector>  // std::vector
+#include <algorithm> // std::transform
+#include <cstdint>   // std::int64_t, std::uint64_t
+#include <iterator>  // std::back_inserter
+#include <utility>   // std::move
+#include <variant>   // std::variant
+#include <vector>    // std::vector
 
 namespace sourcemeta::jsonbinpack::options {
 
@@ -38,15 +41,64 @@ struct DOUBLE_VARINT_TUPLE {};
 // Enumerations
 
 struct BYTE_CHOICE_INDEX {
-  const std::vector<sourcemeta::jsontoolkit::JSON> choices;
+  // Because JSON documents are not easily copyable
+  BYTE_CHOICE_INDEX(const BYTE_CHOICE_INDEX &other) {
+    std::transform(other.choices.cbegin(), other.choices.cend(),
+                   std::back_inserter(this->choices), [](const auto &json) {
+                     return sourcemeta::jsontoolkit::from(json);
+                   });
+  }
+  // Older versions of clang-format seems to get confused
+  // about noexcept constructors.
+  // clang-format off
+  BYTE_CHOICE_INDEX(BYTE_CHOICE_INDEX &&other) noexcept
+      : choices{std::move(other.choices)} {}
+  // clang-format on
+  BYTE_CHOICE_INDEX(std::vector<sourcemeta::jsontoolkit::JSON> &&other)
+      : choices{std::move(other)} {}
+
+  std::vector<sourcemeta::jsontoolkit::JSON> choices;
 };
 
 struct LARGE_CHOICE_INDEX {
-  const std::vector<sourcemeta::jsontoolkit::JSON> choices;
+  // Because JSON documents are not easily copyable
+  LARGE_CHOICE_INDEX(const LARGE_CHOICE_INDEX &other) {
+    std::transform(other.choices.cbegin(), other.choices.cend(),
+                   std::back_inserter(this->choices), [](const auto &json) {
+                     return sourcemeta::jsontoolkit::from(json);
+                   });
+  }
+  // Older versions of clang-format seems to get confused
+  // about noexcept constructors.
+  // clang-format off
+  LARGE_CHOICE_INDEX(LARGE_CHOICE_INDEX &&other) noexcept
+      : choices{std::move(other.choices)} {}
+  // clang-format on
+  LARGE_CHOICE_INDEX(std::vector<sourcemeta::jsontoolkit::JSON> &&other)
+      : choices{std::move(other)} {}
+
+  std::vector<sourcemeta::jsontoolkit::JSON> choices;
 };
 
 struct TOP_LEVEL_BYTE_CHOICE_INDEX {
-  const std::vector<sourcemeta::jsontoolkit::JSON> choices;
+  // Because JSON documents are not easily copyable
+  TOP_LEVEL_BYTE_CHOICE_INDEX(const TOP_LEVEL_BYTE_CHOICE_INDEX &other) {
+    std::transform(other.choices.cbegin(), other.choices.cend(),
+                   std::back_inserter(this->choices), [](const auto &json) {
+                     return sourcemeta::jsontoolkit::from(json);
+                   });
+  }
+  // Older versions of clang-format seems to get confused
+  // about noexcept constructors.
+  // clang-format off
+  TOP_LEVEL_BYTE_CHOICE_INDEX(TOP_LEVEL_BYTE_CHOICE_INDEX &&other) noexcept
+      : choices{std::move(other.choices)} {}
+  // clang-format on
+  TOP_LEVEL_BYTE_CHOICE_INDEX(
+      std::vector<sourcemeta::jsontoolkit::JSON> &&other)
+      : choices{std::move(other)} {}
+
+  std::vector<sourcemeta::jsontoolkit::JSON> choices;
 };
 
 struct CONST_NONE {

--- a/test/options/options_traits_test.cc
+++ b/test/options/options_traits_test.cc
@@ -9,9 +9,9 @@ TEST(Options, encoding_movable) {
   EXPECT_TRUE(std::is_move_constructible_v<Encoding>);
 }
 
-TEST(Options, encoding_not_nothrow_movable) {
+TEST(Options, encoding_nothrow_movable) {
   using namespace sourcemeta::jsonbinpack::options;
-  EXPECT_FALSE(std::is_nothrow_move_constructible_v<Encoding>);
+  EXPECT_TRUE(std::is_nothrow_move_constructible_v<Encoding>);
 }
 
 TEST(Options, encoding_copyable) {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
