### PR TITLE
Don't support moving enum encoding options

### DIFF
--- a/src/options/include/jsonbinpack/options/options.h
+++ b/src/options/include/jsonbinpack/options/options.h
@@ -40,7 +40,6 @@ struct DOUBLE_VARINT_TUPLE {};
 struct BYTE_CHOICE_INDEX {
   // Because JSON documents are not easily copyable
   BYTE_CHOICE_INDEX(const BYTE_CHOICE_INDEX &);
-  BYTE_CHOICE_INDEX(BYTE_CHOICE_INDEX &&) noexcept = default;
   BYTE_CHOICE_INDEX(std::vector<sourcemeta::jsontoolkit::JSON> &&);
   const std::vector<sourcemeta::jsontoolkit::JSON> choices;
 };
@@ -48,7 +47,6 @@ struct BYTE_CHOICE_INDEX {
 struct LARGE_CHOICE_INDEX {
   // Because JSON documents are not easily copyable
   LARGE_CHOICE_INDEX(const LARGE_CHOICE_INDEX &);
-  LARGE_CHOICE_INDEX(LARGE_CHOICE_INDEX &&) noexcept = default;
   LARGE_CHOICE_INDEX(std::vector<sourcemeta::jsontoolkit::JSON> &&);
   const std::vector<sourcemeta::jsontoolkit::JSON> choices;
 };
@@ -56,12 +54,6 @@ struct LARGE_CHOICE_INDEX {
 struct TOP_LEVEL_BYTE_CHOICE_INDEX {
   // Because JSON documents are not easily copyable
   TOP_LEVEL_BYTE_CHOICE_INDEX(const TOP_LEVEL_BYTE_CHOICE_INDEX &);
-  // Older versions of clang-format seems to get
-  // confused about noexcept constructors.
-  // clang-format off
-  TOP_LEVEL_BYTE_CHOICE_INDEX(TOP_LEVEL_BYTE_CHOICE_INDEX &&)
-    noexcept = default;
-  // clang-format on
   TOP_LEVEL_BYTE_CHOICE_INDEX(std::vector<sourcemeta::jsontoolkit::JSON> &&);
   const std::vector<sourcemeta::jsontoolkit::JSON> choices;
 };
@@ -69,7 +61,6 @@ struct TOP_LEVEL_BYTE_CHOICE_INDEX {
 struct CONST_NONE {
   // These constructors allow this encoding to be movable
   CONST_NONE(const sourcemeta::jsontoolkit::JSON &);
-  CONST_NONE(CONST_NONE &&) noexcept;
   CONST_NONE(const CONST_NONE &);
   const sourcemeta::jsontoolkit::JSON value;
 };

--- a/src/options/options.cc
+++ b/src/options/options.cc
@@ -28,8 +28,6 @@ TOP_LEVEL_BYTE_CHOICE_INDEX::TOP_LEVEL_BYTE_CHOICE_INDEX(
 
 CONST_NONE::CONST_NONE(const sourcemeta::jsontoolkit::JSON &input)
     : value{sourcemeta::jsontoolkit::from(input)} {}
-CONST_NONE::CONST_NONE(CONST_NONE &&other) noexcept
-    : value{sourcemeta::jsontoolkit::from(other.value)} {}
 CONST_NONE::CONST_NONE(const CONST_NONE &other)
     : value{sourcemeta::jsontoolkit::from(other.value)} {}
 

--- a/test/options/options_traits_test.cc
+++ b/test/options/options_traits_test.cc
@@ -9,9 +9,9 @@ TEST(Options, encoding_movable) {
   EXPECT_TRUE(std::is_move_constructible_v<Encoding>);
 }
 
-TEST(Options, encoding_nothrow_movable) {
+TEST(Options, encoding_no_nothrow_movable) {
   using namespace sourcemeta::jsonbinpack::options;
-  EXPECT_TRUE(std::is_nothrow_move_constructible_v<Encoding>);
+  EXPECT_FALSE(std::is_nothrow_move_constructible_v<Encoding>);
 }
 
 TEST(Options, encoding_copyable) {


### PR DESCRIPTION
It is hard to move JSON documents. Not defining this by defining the
copy constructor nicely defaults to copying.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
