### PR TITLE
Use `is_byte()` in mapper rules

### DIFF
--- a/src/mapper/CMakeLists.txt
+++ b/src/mapper/CMakeLists.txt
@@ -22,6 +22,7 @@ target_include_directories(sourcemeta_jsonbinpack_mapper PUBLIC
   "${CMAKE_CURRENT_SOURCE_DIR}/include")
 target_link_libraries(sourcemeta_jsonbinpack_mapper PUBLIC sourcemeta_jsontoolkit_json)
 target_link_libraries(sourcemeta_jsonbinpack_mapper PUBLIC sourcemeta_alterschema)
+target_link_libraries(sourcemeta_jsonbinpack_mapper PRIVATE sourcemeta_jsonbinpack_numeric)
 
 # To find the generated schemas file
 target_include_directories(sourcemeta_jsonbinpack_mapper PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")

--- a/src/mapper/mapper.cc
+++ b/src/mapper/mapper.cc
@@ -6,6 +6,7 @@
 // To be used by the rules below
 #include <alterschema/rule.h>
 #include <jsonbinpack/mapper/encoding.h>
+#include <jsonbinpack/numeric/numeric.h>
 
 #include "rules/integer_bounded_8_bit.h"
 #include "rules/integer_bounded_greater_than_8_bit.h"

--- a/src/mapper/rules/integer_bounded_8_bit.h
+++ b/src/mapper/rules/integer_bounded_8_bit.h
@@ -21,11 +21,10 @@ public:
                sourcemeta::jsontoolkit::at(schema, "type")) == "integer" &&
            sourcemeta::jsontoolkit::defines(schema, "minimum") &&
            sourcemeta::jsontoolkit::defines(schema, "maximum") &&
-           sourcemeta::jsontoolkit::to_integer(
-               sourcemeta::jsontoolkit::at(schema, "maximum")) -
+           is_byte(sourcemeta::jsontoolkit::to_integer(
+                       sourcemeta::jsontoolkit::at(schema, "maximum")) -
                    sourcemeta::jsontoolkit::to_integer(
-                       sourcemeta::jsontoolkit::at(schema, "minimum")) <=
-               std::numeric_limits<std::uint8_t>::max() &&
+                       sourcemeta::jsontoolkit::at(schema, "minimum"))) &&
            !sourcemeta::jsontoolkit::defines(schema, "multipleOf");
   }
 

--- a/src/mapper/rules/integer_bounded_greater_than_8_bit.h
+++ b/src/mapper/rules/integer_bounded_greater_than_8_bit.h
@@ -23,11 +23,10 @@ public:
                sourcemeta::jsontoolkit::at(schema, "type")) == "integer" &&
            sourcemeta::jsontoolkit::defines(schema, "minimum") &&
            sourcemeta::jsontoolkit::defines(schema, "maximum") &&
-           sourcemeta::jsontoolkit::to_integer(
-               sourcemeta::jsontoolkit::at(schema, "maximum")) -
-                   sourcemeta::jsontoolkit::to_integer(
-                       sourcemeta::jsontoolkit::at(schema, "minimum")) >
-               std::numeric_limits<std::uint8_t>::max() &&
+           !is_byte(sourcemeta::jsontoolkit::to_integer(
+                        sourcemeta::jsontoolkit::at(schema, "maximum")) -
+                    sourcemeta::jsontoolkit::to_integer(
+                        sourcemeta::jsontoolkit::at(schema, "minimum"))) &&
            !sourcemeta::jsontoolkit::defines(schema, "multipleOf");
   }
 


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
