### PR TITLE
Implement the `VARINT_TYPED_ARBITRARY_OBJECT` encoding

### DIFF
--- a/src/decoder/include/jsonbinpack/decoder/decoder.h
+++ b/src/decoder/include/jsonbinpack/decoder/decoder.h
@@ -49,6 +49,7 @@ public:
       HANDLE_DECODING(16, FLOOR_TYPED_ARRAY)
       HANDLE_DECODING(17, ROOF_TYPED_ARRAY)
       HANDLE_DECODING(18, FIXED_TYPED_ARBITRARY_OBJECT)
+      HANDLE_DECODING(19, VARINT_TYPED_ARBITRARY_OBJECT)
 #undef HANDLE_DECODING
     default:
       // We should never get here. If so, it is definitely a bug
@@ -376,6 +377,25 @@ public:
     }
 
     assert(sourcemeta::jsontoolkit::size(document) == options.size);
+    return document;
+  };
+
+  auto
+  VARINT_TYPED_ARBITRARY_OBJECT(const VARINT_TYPED_ARBITRARY_OBJECT &options)
+      -> sourcemeta::jsontoolkit::JSON {
+    const std::uint64_t size{this->get_varint()};
+    sourcemeta::jsontoolkit::JSON document{
+        sourcemeta::jsontoolkit::make_object()};
+    for (std::size_t index = 0; index < size; index++) {
+      const sourcemeta::jsontoolkit::JSON key{
+          this->decode(options.key_encoding->value)};
+      assert(sourcemeta::jsontoolkit::is_string(key));
+      sourcemeta::jsontoolkit::assign(document,
+                                      sourcemeta::jsontoolkit::to_string(key),
+                                      this->decode(options.encoding->value));
+    }
+
+    assert(sourcemeta::jsontoolkit::size(document) == size);
     return document;
   };
 

--- a/src/encoder/include/jsonbinpack/encoder/encoder.h
+++ b/src/encoder/include/jsonbinpack/encoder/encoder.h
@@ -50,6 +50,7 @@ public:
       HANDLE_ENCODING(16, FLOOR_TYPED_ARRAY)
       HANDLE_ENCODING(17, ROOF_TYPED_ARRAY)
       HANDLE_ENCODING(18, FIXED_TYPED_ARBITRARY_OBJECT)
+      HANDLE_ENCODING(19, VARINT_TYPED_ARBITRARY_OBJECT)
 #undef HANDLE_ENCODING
     default:
       // We should never get here. If so, it is definitely a bug
@@ -388,6 +389,23 @@ public:
       -> void {
     assert(sourcemeta::jsontoolkit::is_object(document));
     assert(sourcemeta::jsontoolkit::size(document) == options.size);
+    for (const auto &pair :
+         sourcemeta::jsontoolkit::object_iterator(document)) {
+      this->encode(
+          sourcemeta::jsontoolkit::from(sourcemeta::jsontoolkit::key(pair)),
+          options.key_encoding->value);
+      this->encode(sourcemeta::jsontoolkit::value(pair),
+                   options.encoding->value);
+    }
+  }
+
+  auto
+  VARINT_TYPED_ARBITRARY_OBJECT(const sourcemeta::jsontoolkit::Value &document,
+                                const VARINT_TYPED_ARBITRARY_OBJECT &options)
+      -> void {
+    assert(sourcemeta::jsontoolkit::is_object(document));
+    const auto size{sourcemeta::jsontoolkit::size(document)};
+    this->put_varint(size);
     for (const auto &pair :
          sourcemeta::jsontoolkit::object_iterator(document)) {
       this->encode(

--- a/src/encoding/include/jsonbinpack/encoding/encoding.h
+++ b/src/encoding/include/jsonbinpack/encoding/encoding.h
@@ -283,20 +283,34 @@ struct FIXED_TYPED_ARBITRARY_OBJECT {
   const SingleEncoding encoding;
 };
 
+/// @brief The encoding consists of the number of key-value pairs in the input
+/// object as a Base-128 64-bit Little Endian variable-length unsigned integer
+/// followed by each pair encoded as the key followed by the value according to
+/// `key_encoding` and `encoding`. The order in which pairs are encoded is
+/// undefined.
+struct VARINT_TYPED_ARBITRARY_OBJECT {
+  /// Key encoding
+  const SingleEncoding key_encoding;
+  /// Value encoding
+  const SingleEncoding encoding;
+};
+
 /// @}
 
 // Encoding type
 
-using Encoding = std::variant<
-    BOUNDED_MULTIPLE_8BITS_ENUM_FIXED, FLOOR_MULTIPLE_ENUM_VARINT,
-    ROOF_MULTIPLE_MIRROR_ENUM_VARINT, ARBITRARY_MULTIPLE_ZIGZAG_VARINT,
-    DOUBLE_VARINT_TUPLE, BYTE_CHOICE_INDEX, LARGE_CHOICE_INDEX,
-    TOP_LEVEL_BYTE_CHOICE_INDEX, CONST_NONE, UTF8_STRING_NO_LENGTH,
-    FLOOR_VARINT_PREFIX_UTF8_STRING_SHARED,
-    ROOF_VARINT_PREFIX_UTF8_STRING_SHARED,
-    BOUNDED_8BIT_PREFIX_UTF8_STRING_SHARED, RFC3339_DATE_INTEGER_TRIPLET,
-    FIXED_TYPED_ARRAY, BOUNDED_8BITS_TYPED_ARRAY, FLOOR_TYPED_ARRAY,
-    ROOF_TYPED_ARRAY, FIXED_TYPED_ARBITRARY_OBJECT>;
+using Encoding =
+    std::variant<BOUNDED_MULTIPLE_8BITS_ENUM_FIXED, FLOOR_MULTIPLE_ENUM_VARINT,
+                 ROOF_MULTIPLE_MIRROR_ENUM_VARINT,
+                 ARBITRARY_MULTIPLE_ZIGZAG_VARINT, DOUBLE_VARINT_TUPLE,
+                 BYTE_CHOICE_INDEX, LARGE_CHOICE_INDEX,
+                 TOP_LEVEL_BYTE_CHOICE_INDEX, CONST_NONE, UTF8_STRING_NO_LENGTH,
+                 FLOOR_VARINT_PREFIX_UTF8_STRING_SHARED,
+                 ROOF_VARINT_PREFIX_UTF8_STRING_SHARED,
+                 BOUNDED_8BIT_PREFIX_UTF8_STRING_SHARED,
+                 RFC3339_DATE_INTEGER_TRIPLET, FIXED_TYPED_ARRAY,
+                 BOUNDED_8BITS_TYPED_ARRAY, FLOOR_TYPED_ARRAY, ROOF_TYPED_ARRAY,
+                 FIXED_TYPED_ARBITRARY_OBJECT, VARINT_TYPED_ARBITRARY_OBJECT>;
 
 // Helper definitions that rely on the Encoding data type
 #ifndef DOXYGEN

--- a/test/decoder/decode_object_test.cc
+++ b/test/decoder/decode_object_test.cc
@@ -29,3 +29,29 @@ TEST(Decoder, FIXED_TYPED_ARBITRARY_OBJECT__no_length_string__integer) {
   EXPECT_EQ(sourcemeta::jsontoolkit::to_integer(foo), 1);
   EXPECT_EQ(sourcemeta::jsontoolkit::to_integer(bar), 2);
 }
+
+TEST(Decoder, VARINT_TYPED_ARBITRARY_OBJECT__no_length_string__integer) {
+  using namespace sourcemeta::jsonbinpack;
+  InputByteStream<char> stream{
+      0x02,             // length 2
+      0x66, 0x6f, 0x6f, // "foo"
+      0x01,             // 1
+      0x62, 0x61, 0x72, // "bar"
+      0x02              // 2
+  };
+  Decoder decoder{stream};
+  const sourcemeta::jsontoolkit::JSON result{
+      decoder.VARINT_TYPED_ARBITRARY_OBJECT(
+          {wrap(UTF8_STRING_NO_LENGTH{3}),
+           wrap(BOUNDED_MULTIPLE_8BITS_ENUM_FIXED{0, 10, 1})})};
+  EXPECT_TRUE(sourcemeta::jsontoolkit::is_object(result));
+  EXPECT_EQ(sourcemeta::jsontoolkit::size(result), 2);
+  EXPECT_TRUE(sourcemeta::jsontoolkit::defines(result, "foo"));
+  EXPECT_TRUE(sourcemeta::jsontoolkit::defines(result, "bar"));
+  const auto &foo{sourcemeta::jsontoolkit::at(result, "foo")};
+  const auto &bar{sourcemeta::jsontoolkit::at(result, "bar")};
+  EXPECT_TRUE(sourcemeta::jsontoolkit::is_integer(foo));
+  EXPECT_TRUE(sourcemeta::jsontoolkit::is_integer(bar));
+  EXPECT_EQ(sourcemeta::jsontoolkit::to_integer(foo), 1);
+  EXPECT_EQ(sourcemeta::jsontoolkit::to_integer(bar), 2);
+}

--- a/test/encoder/encode_object_test.cc
+++ b/test/encoder/encode_object_test.cc
@@ -22,3 +22,22 @@ TEST(Encoder, FIXED_TYPED_ARBITRARY_OBJECT__no_length_string__integer) {
                            0x02              // 2
                        });
 }
+
+TEST(Encoder, VARINT_TYPED_ARBITRARY_OBJECT__no_length_string__integer) {
+  using namespace sourcemeta::jsonbinpack;
+  sourcemeta::jsontoolkit::JSON document{
+      sourcemeta::jsontoolkit::parse("{\"foo\":1,\"bar\":2}")};
+  OutputByteStream<char> stream{};
+
+  Encoder encoder{stream};
+  encoder.VARINT_TYPED_ARBITRARY_OBJECT(
+      document, {wrap(UTF8_STRING_NO_LENGTH{3}),
+                 wrap(BOUNDED_MULTIPLE_8BITS_ENUM_FIXED{0, 10, 1})});
+  EXPECT_BYTES(stream, {
+                           0x02,             // length 2
+                           0x66, 0x6f, 0x6f, // "foo"
+                           0x01,             // 1
+                           0x62, 0x61, 0x72, // "bar"
+                           0x02              // 2
+                       });
+}

--- a/www/_docs/encoder/object.markdown
+++ b/www/_docs/encoder/object.markdown
@@ -46,3 +46,41 @@ Or:
 +------+------+------+------+------+------+------+------+
   b      a      r      2      f      o      o      1
 ```
+
+`VARINT_TYPED_ARBITRARY_OBJECT`
+-------------------------------
+
+The encoding consists of the number of key-value pairs in the input object as a
+Base-128 64-bit Little Endian variable-length unsigned integer followed by each
+pair encoded as the key followed by the value according to `keyEncoding` and
+`encoding`. The order in which pairs are encoded is undefined.
+
+### Options
+
+| Option        | Type       | Description    |
+|---------------|------------|----------------|
+| `keyEncoding` | `encoding` | Key encoding   |
+| `encoding`    | `encoding` | Value encoding |
+
+### Examples
+
+Given the array `{ "foo": 1, "bar": 2 }` where `keyEncoding` corresponds to
+[`UTF8_STRING_NO_LENGTH`](./string) (size 3) and `encoding` corresponds to
+[`BOUNDED_MULTIPLE_8BITS_ENUM_FIXED`](./integer) (minimum 0, maximum 10,
+multiplier 1), the encoding results in:
+
+```
++------+------+------+------+------+------+------+------+------+
+| 0x02 | 0x66 | 0x6f | 0x6f | 0x01 | 0x62 | 0x61 | 0x72 | 0x02 |
++------+------+------+------+------+------+------+------+------+
+  2      f      o      o      1      b      a      r      2
+```
+
+Or:
+
+```
++------+------+------+------+------+------+------+------+------+
+| 0x02 | 0x62 | 0x61 | 0x72 | 0x02 | 0x66 | 0x6f | 0x6f | 0x01 |
++------+------+------+------+------+------+------+------+------+
+  2      b      a      r      2      f      o      o      1
+```


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
