### PR TITLE
Rename compiler `map()` to `plan()`

### DIFF
--- a/src/compiler/compiler.cc
+++ b/src/compiler/compiler.cc
@@ -10,7 +10,7 @@ auto compile(sourcemeta::jsontoolkit::JSON &schema,
              const sourcemeta::jsontoolkit::SchemaResolver &resolver,
              const std::optional<std::string> &default_dialect) -> void {
   canonicalize(schema, walker, resolver, default_dialect);
-  map(schema, walker, resolver, default_dialect);
+  plan(schema, walker, resolver, default_dialect);
 }
 
 auto canonicalize(sourcemeta::jsontoolkit::JSON &schema,
@@ -21,10 +21,10 @@ auto canonicalize(sourcemeta::jsontoolkit::JSON &schema,
   canonicalizer.apply(schema, walker, resolver, default_dialect);
 }
 
-auto map(sourcemeta::jsontoolkit::JSON &schema,
-         const sourcemeta::jsontoolkit::SchemaWalker &walker,
-         const sourcemeta::jsontoolkit::SchemaResolver &resolver,
-         const std::optional<std::string> &default_dialect) -> void {
+auto plan(sourcemeta::jsontoolkit::JSON &schema,
+          const sourcemeta::jsontoolkit::SchemaWalker &walker,
+          const sourcemeta::jsontoolkit::SchemaResolver &resolver,
+          const std::optional<std::string> &default_dialect) -> void {
   static sourcemeta::jsonbinpack::Mapper mapper;
   mapper.apply(schema, walker, resolver, default_dialect);
 }

--- a/src/compiler/include/sourcemeta/jsonbinpack/compiler.h
+++ b/src/compiler/include/sourcemeta/jsonbinpack/compiler.h
@@ -21,11 +21,10 @@ auto canonicalize(
     const sourcemeta::jsontoolkit::SchemaResolver &resolver,
     const std::optional<std::string> &default_dialect = std::nullopt) -> void;
 
-// TODO: Rename to plan()?
-auto map(sourcemeta::jsontoolkit::JSON &schema,
-         const sourcemeta::jsontoolkit::SchemaWalker &walker,
-         const sourcemeta::jsontoolkit::SchemaResolver &resolver,
-         const std::optional<std::string> &default_dialect = std::nullopt)
+auto plan(sourcemeta::jsontoolkit::JSON &schema,
+          const sourcemeta::jsontoolkit::SchemaWalker &walker,
+          const sourcemeta::jsontoolkit::SchemaResolver &resolver,
+          const std::optional<std::string> &default_dialect = std::nullopt)
     -> void;
 
 } // namespace sourcemeta::jsonbinpack

--- a/test/compiler/CMakeLists.txt
+++ b/test/compiler/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable(sourcemeta_jsonbinpack_compiler_unit
-  canonicalizer_test.cc
+  canonicalizer_test.cc plan_test.cc
+
   2020_12_canonicalizer_any_test.cc
   2020_12_canonicalizer_array_test.cc
   2020_12_canonicalizer_boolean_test.cc
@@ -8,7 +9,6 @@ add_executable(sourcemeta_jsonbinpack_compiler_unit
   2020_12_canonicalizer_object_test.cc
   2020_12_canonicalizer_string_test.cc
 
-  mapper_test.cc
   2020_12_compiler_any_test.cc
   2020_12_compiler_enum_test.cc
   2020_12_compiler_integer_test.cc

--- a/test/compiler/plan_test.cc
+++ b/test/compiler/plan_test.cc
@@ -5,28 +5,28 @@
 
 #include <stdexcept>
 
-TEST(JSONBinPack_Mapper, unsupported_draft) {
+TEST(JSONBinPack_Plan, unsupported_draft) {
   sourcemeta::jsontoolkit::JSON schema = sourcemeta::jsontoolkit::parse(R"JSON({
     "$schema": "https://json-schema.org/draft/2019-09/schema",
     "type": "boolean"
   })JSON");
 
-  EXPECT_THROW(sourcemeta::jsonbinpack::map(
+  EXPECT_THROW(sourcemeta::jsonbinpack::plan(
                    schema, sourcemeta::jsontoolkit::default_schema_walker,
                    sourcemeta::jsontoolkit::official_resolver,
                    "https://json-schema.org/draft/2020-12/schema"),
                std::domain_error);
 }
 
-TEST(JSONBinPack_Mapper, unknown_draft_default) {
+TEST(JSONBinPack_Plan, unknown_draft_default) {
   sourcemeta::jsontoolkit::JSON schema = sourcemeta::jsontoolkit::parse(R"JSON({
     "type": "integer"
   })JSON");
 
-  sourcemeta::jsonbinpack::map(schema,
-                               sourcemeta::jsontoolkit::default_schema_walker,
-                               sourcemeta::jsontoolkit::official_resolver,
-                               "https://json-schema.org/draft/2020-12/schema");
+  sourcemeta::jsonbinpack::plan(schema,
+                                sourcemeta::jsontoolkit::default_schema_walker,
+                                sourcemeta::jsontoolkit::official_resolver,
+                                "https://json-schema.org/draft/2020-12/schema");
 
   const sourcemeta::jsontoolkit::JSON expected =
       sourcemeta::jsontoolkit::parse(R"JSON({

--- a/test/e2e/runner.cc
+++ b/test/e2e/runner.cc
@@ -47,17 +47,17 @@ auto main(int argc, char *argv[]) -> int {
   canonical_output_stream.flush();
   canonical_output_stream.close();
 
-  // Mapper
-  sourcemeta::jsonbinpack::map(
+  // Plan
+  sourcemeta::jsonbinpack::plan(
       schema, sourcemeta::jsontoolkit::default_schema_walker,
       sourcemeta::jsontoolkit::official_resolver, DEFAULT_METASCHEMA);
 
-  std::ofstream mapper_output_stream(directory / "plan.json", std::ios::binary);
-  mapper_output_stream.exceptions(std::ios_base::badbit);
-  sourcemeta::jsontoolkit::prettify(schema, mapper_output_stream);
-  mapper_output_stream << "\n";
-  mapper_output_stream.flush();
-  mapper_output_stream.close();
+  std::ofstream plan_output_stream(directory / "plan.json", std::ios::binary);
+  plan_output_stream.exceptions(std::ios_base::badbit);
+  sourcemeta::jsontoolkit::prettify(schema, plan_output_stream);
+  plan_output_stream << "\n";
+  plan_output_stream.flush();
+  plan_output_stream.close();
 
   // Encoder
   const sourcemeta::jsonbinpack::Plan plan{


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
