### PR TITLE
Don't canonicalize `false` to `{ not: {} }`

### DIFF
--- a/src/compiler/CMakeLists.txt
+++ b/src/compiler/CMakeLists.txt
@@ -4,7 +4,7 @@ noa_library(NAMESPACE sourcemeta PROJECT jsonbinpack NAME compiler
     canonicalizer.h mapper.h states.h schemas.h
     compiler.cc
 
-    canonicalizer_rules/boolean_schema.h
+    canonicalizer_rules/boolean_schema_true.h
     canonicalizer_rules/equal_numeric_bounds_as_const.h
 
     canonicalizer_rules/drop_non_array_keywords_validation.h

--- a/src/compiler/canonicalizer.h
+++ b/src/compiler/canonicalizer.h
@@ -16,7 +16,7 @@
 namespace sourcemeta::jsonbinpack {
 
 // Rules
-#include "canonicalizer_rules/boolean_schema.h"
+#include "canonicalizer_rules/boolean_schema_true.h"
 #include "canonicalizer_rules/equal_numeric_bounds_as_const.h"
 
 #include "canonicalizer_rules/drop_non_array_keywords_validation.h"
@@ -46,7 +46,7 @@ public:
     sourcemeta::alterschema::add(
         *this, sourcemeta::alterschema::LinterCategory::Desugar);
 
-    this->add<BooleanSchema>();
+    this->add<BooleanSchemaTrue>();
     this->add<EqualNumericBoundsAsConst>();
 
     // TODO: Check these

--- a/src/compiler/canonicalizer_rules/boolean_schema_true.h
+++ b/src/compiler/canonicalizer_rules/boolean_schema_true.h
@@ -1,20 +1,16 @@
-class BooleanSchema final : public sourcemeta::alterschema::Rule {
+class BooleanSchemaTrue final : public sourcemeta::alterschema::Rule {
 public:
-  BooleanSchema() : Rule("boolean_schema", "TODO") {};
+  BooleanSchemaTrue() : Rule("boolean_schema_true", "TODO") {};
 
   [[nodiscard]] auto
   condition(const sourcemeta::jsontoolkit::JSON &schema, const std::string &,
             const std::set<std::string> &,
             const sourcemeta::jsontoolkit::Pointer &) const -> bool override {
-    return schema.is_boolean();
+    return schema.is_boolean() && schema.to_boolean();
   }
 
   auto transform(sourcemeta::alterschema::Transformer &transformer) const
       -> void override {
-    const bool current_value{transformer.schema().to_boolean()};
     transformer.replace(sourcemeta::jsontoolkit::JSON::make_object());
-    if (!current_value) {
-      transformer.assign("not", sourcemeta::jsontoolkit::JSON::make_object());
-    }
   }
 };

--- a/src/compiler/canonicalizer_rules/drop_non_array_keywords_validation.h
+++ b/src/compiler/canonicalizer_rules/drop_non_array_keywords_validation.h
@@ -12,7 +12,8 @@ public:
     return dialect == "https://json-schema.org/draft/2020-12/schema" &&
            vocabularies.contains(
                "https://json-schema.org/draft/2020-12/vocab/validation") &&
-           schema.defines("type") && schema.at("type").is_string() &&
+           schema.is_object() && schema.defines("type") &&
+           schema.at("type").is_string() &&
            schema.at("type").to_string() == "array" &&
            schema.defines_any(this->BLACKLIST_VALIDATION.cbegin(),
                               this->BLACKLIST_VALIDATION.cend());

--- a/src/compiler/canonicalizer_rules/implicit_type_union.h
+++ b/src/compiler/canonicalizer_rules/implicit_type_union.h
@@ -10,16 +10,17 @@ public:
     const bool has_core_blacklist{
         vocabularies.contains(
             "https://json-schema.org/draft/2020-12/vocab/core") &&
-        schema.defines_any({"$ref", "$dynamicRef"})};
+        schema.is_object() && schema.defines_any({"$ref", "$dynamicRef"})};
     const bool has_applicator_blacklist{
         vocabularies.contains(
             "https://json-schema.org/draft/2020-12/vocab/applicator") &&
+        schema.is_object() &&
         schema.defines_any(
             {"anyOf", "allOf", "oneOf", "not", "if", "then", "else"})};
     const bool has_validation_blacklist{
         vocabularies.contains(
             "https://json-schema.org/draft/2020-12/vocab/validation") &&
-        schema.defines_any({"type", "const", "enum"})};
+        schema.is_object() && schema.defines_any({"type", "const", "enum"})};
 
     return dialect == "https://json-schema.org/draft/2020-12/schema" &&
            vocabularies.contains(

--- a/test/compiler/2020_12_canonicalizer_any_test.cc
+++ b/test/compiler/2020_12_canonicalizer_any_test.cc
@@ -419,35 +419,6 @@ TEST(JSONBinPack_Canonicalizer_Any_2020_12, boolean_schema_2) {
       sourcemeta::jsontoolkit::official_resolver,
       "https://json-schema.org/draft/2020-12/schema");
 
-  const sourcemeta::jsontoolkit::JSON expected =
-      sourcemeta::jsontoolkit::parse(R"JSON({
-    "not": {
-      "anyOf": [
-        { "enum": [ null ] },
-        { "enum": [ false, true ] },
-        {
-          "type": "object",
-          "minProperties": 0,
-          "properties": {}
-        },
-        {
-          "type": "array",
-          "minItems": 0
-        },
-        {
-          "type": "string",
-          "minLength": 0
-        },
-        {
-          "type": "number"
-        },
-        {
-          "type": "integer",
-          "multipleOf": 1
-        }
-      ]
-    }
-  })JSON");
-
+  const sourcemeta::jsontoolkit::JSON expected{false};
   EXPECT_EQ(schema, expected);
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
