### PR TITLE
Rename `BasicDecoder`/`BasicEncoder` to `InputStream`/`OutputStream`

### DIFF
--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -1,8 +1,10 @@
 noa_library(NAMESPACE sourcemeta PROJECT jsonbinpack NAME runtime
   FOLDER "JSON BinPack/Runtime"
   PRIVATE_HEADERS
-    decoder.h decoder_basic.h
-    encoder.h encoder_basic.h encoder_context.h
+    decoder.h encoder.h
+    input_stream.h
+    output_stream.h
+    encoder_context.h
     plan.h plan_wrap.h varint.h
   SOURCES
     loader.cc loader_v1.h

--- a/src/runtime/decoder_common.cc
+++ b/src/runtime/decoder_common.cc
@@ -6,7 +6,7 @@
 
 namespace sourcemeta::jsonbinpack {
 
-Decoder::Decoder(Stream &input) : BasicDecoder{input} {}
+Decoder::Decoder(Stream &input) : InputStream{input} {}
 
 auto Decoder::read(const Plan &encoding) -> sourcemeta::jsontoolkit::JSON {
   switch (encoding.index()) {

--- a/src/runtime/encoder_common.cc
+++ b/src/runtime/encoder_common.cc
@@ -6,7 +6,7 @@
 
 namespace sourcemeta::jsonbinpack {
 
-Encoder::Encoder(Stream &output) : BasicEncoder{output} {}
+Encoder::Encoder(Stream &output) : OutputStream{output} {}
 
 auto Encoder::write(const sourcemeta::jsontoolkit::JSON &document,
                     const Plan &encoding) -> void {

--- a/src/runtime/include/sourcemeta/jsonbinpack/runtime_decoder.h
+++ b/src/runtime/include/sourcemeta/jsonbinpack/runtime_decoder.h
@@ -3,7 +3,7 @@
 
 #include "runtime_export.h"
 
-#include <sourcemeta/jsonbinpack/runtime_decoder_basic.h>
+#include <sourcemeta/jsonbinpack/runtime_input_stream.h>
 #include <sourcemeta/jsonbinpack/runtime_plan.h>
 
 #include <sourcemeta/jsontoolkit/json.h>
@@ -13,7 +13,7 @@
 namespace sourcemeta::jsonbinpack {
 
 /// @ingroup runtime
-class SOURCEMETA_JSONBINPACK_RUNTIME_EXPORT Decoder : private BasicDecoder {
+class SOURCEMETA_JSONBINPACK_RUNTIME_EXPORT Decoder : private InputStream {
 public:
   using Stream = std::basic_istream<sourcemeta::jsontoolkit::JSON::Char,
                                     sourcemeta::jsontoolkit::JSON::CharTraits>;

--- a/src/runtime/include/sourcemeta/jsonbinpack/runtime_encoder.h
+++ b/src/runtime/include/sourcemeta/jsonbinpack/runtime_encoder.h
@@ -3,7 +3,7 @@
 
 #include "runtime_export.h"
 
-#include <sourcemeta/jsonbinpack/runtime_encoder_basic.h>
+#include <sourcemeta/jsonbinpack/runtime_output_stream.h>
 #include <sourcemeta/jsonbinpack/runtime_plan.h>
 
 #include <sourcemeta/jsontoolkit/json.h>
@@ -13,7 +13,7 @@
 namespace sourcemeta::jsonbinpack {
 
 /// @ingroup runtime
-class SOURCEMETA_JSONBINPACK_RUNTIME_EXPORT Encoder : private BasicEncoder {
+class SOURCEMETA_JSONBINPACK_RUNTIME_EXPORT Encoder : private OutputStream {
 public:
   using Stream = std::basic_ostream<sourcemeta::jsontoolkit::JSON::Char,
                                     sourcemeta::jsontoolkit::JSON::CharTraits>;

--- a/src/runtime/include/sourcemeta/jsonbinpack/runtime_input_stream.h
+++ b/src/runtime/include/sourcemeta/jsonbinpack/runtime_input_stream.h
@@ -1,5 +1,5 @@
-#ifndef SOURCEMETA_JSONBINPACK_RUNTIME_DECODER_BASIC_H_
-#define SOURCEMETA_JSONBINPACK_RUNTIME_DECODER_BASIC_H_
+#ifndef SOURCEMETA_JSONBINPACK_RUNTIME_INPUT_STREAM_H_
+#define SOURCEMETA_JSONBINPACK_RUNTIME_INPUT_STREAM_H_
 #ifndef DOXYGEN
 
 #include "runtime_export.h"
@@ -18,9 +18,9 @@
 namespace sourcemeta::jsonbinpack {
 
 /// @ingroup runtime
-class SOURCEMETA_JSONBINPACK_RUNTIME_EXPORT BasicDecoder {
+class SOURCEMETA_JSONBINPACK_RUNTIME_EXPORT InputStream {
 public:
-  BasicDecoder(
+  InputStream(
       std::basic_istream<sourcemeta::jsontoolkit::JSON::Char,
                          sourcemeta::jsontoolkit::JSON::CharTraits> &input)
       : stream{input} {
@@ -29,8 +29,8 @@ public:
   }
 
   // Prevent copying, as this class is tied to a stream resource
-  BasicDecoder(const BasicDecoder &) = delete;
-  auto operator=(const BasicDecoder &) -> BasicDecoder & = delete;
+  InputStream(const InputStream &) = delete;
+  auto operator=(const InputStream &) -> InputStream & = delete;
 
   inline auto position() const noexcept -> std::uint64_t {
     return static_cast<std::uint64_t>(this->stream.tellg());

--- a/src/runtime/include/sourcemeta/jsonbinpack/runtime_output_stream.h
+++ b/src/runtime/include/sourcemeta/jsonbinpack/runtime_output_stream.h
@@ -1,5 +1,5 @@
-#ifndef SOURCEMETA_JSONBINPACK_RUNTIME_ENCODER_BASIC_H_
-#define SOURCEMETA_JSONBINPACK_RUNTIME_ENCODER_BASIC_H_
+#ifndef SOURCEMETA_JSONBINPACK_RUNTIME_OUTPUT_STREAM_H_
+#define SOURCEMETA_JSONBINPACK_RUNTIME_OUTPUT_STREAM_H_
 #ifndef DOXYGEN
 
 #include "runtime_export.h"
@@ -20,9 +20,9 @@
 namespace sourcemeta::jsonbinpack {
 
 /// @ingroup runtime
-class SOURCEMETA_JSONBINPACK_RUNTIME_EXPORT BasicEncoder {
+class SOURCEMETA_JSONBINPACK_RUNTIME_EXPORT OutputStream {
 public:
-  BasicEncoder(
+  OutputStream(
       std::basic_ostream<sourcemeta::jsontoolkit::JSON::Char,
                          sourcemeta::jsontoolkit::JSON::CharTraits> &output)
       : stream{output} {
@@ -31,8 +31,8 @@ public:
   }
 
   // Prevent copying, as this class is tied to a stream resource
-  BasicEncoder(const BasicEncoder &) = delete;
-  auto operator=(const BasicEncoder &) -> BasicEncoder & = delete;
+  OutputStream(const OutputStream &) = delete;
+  auto operator=(const OutputStream &) -> OutputStream & = delete;
 
   inline auto position() const noexcept -> std::uint64_t {
     return static_cast<std::uint64_t>(this->stream.tellp());


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
