### PR TITLE
Move `OutputStream`/`InputStream` definitions outside of the headers

### DIFF
--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -8,6 +8,8 @@ noa_library(NAMESPACE sourcemeta PROJECT jsonbinpack NAME runtime
     plan.h plan_wrap.h varint.h
   SOURCES
     loader.cc loader_v1.h
+    input_stream.cc
+    output_stream.cc
     decoder_any.cc
     decoder_array.cc
     decoder_common.cc

--- a/src/runtime/include/sourcemeta/jsonbinpack/runtime_decoder.h
+++ b/src/runtime/include/sourcemeta/jsonbinpack/runtime_decoder.h
@@ -8,15 +8,11 @@
 
 #include <sourcemeta/jsontoolkit/json.h>
 
-#include <istream> // std::basic_istream
-
 namespace sourcemeta::jsonbinpack {
 
 /// @ingroup runtime
 class SOURCEMETA_JSONBINPACK_RUNTIME_EXPORT Decoder : private InputStream {
 public:
-  using Stream = std::basic_istream<sourcemeta::jsontoolkit::JSON::Char,
-                                    sourcemeta::jsontoolkit::JSON::CharTraits>;
   Decoder(Stream &input);
   auto read(const Plan &encoding) -> sourcemeta::jsontoolkit::JSON;
 

--- a/src/runtime/include/sourcemeta/jsonbinpack/runtime_encoder.h
+++ b/src/runtime/include/sourcemeta/jsonbinpack/runtime_encoder.h
@@ -8,15 +8,11 @@
 
 #include <sourcemeta/jsontoolkit/json.h>
 
-#include <ostream> // std::basic_ostream
-
 namespace sourcemeta::jsonbinpack {
 
 /// @ingroup runtime
 class SOURCEMETA_JSONBINPACK_RUNTIME_EXPORT Encoder : private OutputStream {
 public:
-  using Stream = std::basic_ostream<sourcemeta::jsontoolkit::JSON::Char,
-                                    sourcemeta::jsontoolkit::JSON::CharTraits>;
   Encoder(Stream &output);
   auto write(const sourcemeta::jsontoolkit::JSON &document,
              const Plan &encoding) -> void;

--- a/src/runtime/include/sourcemeta/jsonbinpack/runtime_input_stream.h
+++ b/src/runtime/include/sourcemeta/jsonbinpack/runtime_input_stream.h
@@ -1,18 +1,11 @@
 #ifndef SOURCEMETA_JSONBINPACK_RUNTIME_INPUT_STREAM_H_
 #define SOURCEMETA_JSONBINPACK_RUNTIME_INPUT_STREAM_H_
-#ifndef DOXYGEN
 
 #include "runtime_export.h"
 
-#include <sourcemeta/jsonbinpack/numeric.h>
 #include <sourcemeta/jsontoolkit/json.h>
 
-#include <sourcemeta/jsonbinpack/runtime_varint.h>
-
-#include <cassert> // assert
-#include <cmath>   // std::ceil
-#include <cstdint> // std::uint8_t, std::int64_t, std::uint64_t
-#include <ios>     // std::ios_base
+#include <cstdint> // std::uint8_t, std::uint16_t, std::uint64_t
 #include <istream> // std::basic_istream
 
 namespace sourcemeta::jsonbinpack {
@@ -20,90 +13,32 @@ namespace sourcemeta::jsonbinpack {
 /// @ingroup runtime
 class SOURCEMETA_JSONBINPACK_RUNTIME_EXPORT InputStream {
 public:
-  InputStream(
-      std::basic_istream<sourcemeta::jsontoolkit::JSON::Char,
-                         sourcemeta::jsontoolkit::JSON::CharTraits> &input)
-      : stream{input} {
-    this->stream.exceptions(std::ios_base::badbit | std::ios_base::failbit |
-                            std::ios_base::eofbit);
-  }
-
+  using Stream = std::basic_istream<sourcemeta::jsontoolkit::JSON::Char,
+                                    sourcemeta::jsontoolkit::JSON::CharTraits>;
+  InputStream(Stream &input);
   // Prevent copying, as this class is tied to a stream resource
   InputStream(const InputStream &) = delete;
   auto operator=(const InputStream &) -> InputStream & = delete;
 
-  inline auto position() const noexcept -> std::uint64_t {
-    return static_cast<std::uint64_t>(this->stream.tellg());
-  }
-
-  inline auto seek(const std::uint64_t offset) -> void {
-    this->stream.seekg(static_cast<std::streamoff>(offset));
-  }
-
+  auto position() const noexcept -> std::uint64_t;
+  auto seek(const std::uint64_t offset) -> void;
   // Seek backwards given a relative offset
-  inline auto rewind(const std::uint64_t relative_offset,
-                     const std::uint64_t position) -> std::uint64_t {
-    assert(position >= relative_offset);
-    const std::uint64_t offset{position - relative_offset};
-    assert(offset < position);
-    const std::uint64_t current{this->position()};
-    this->seek(offset);
-    return current;
-  }
-
-  inline auto get_byte() -> std::uint8_t {
-    return static_cast<std::uint8_t>(this->stream.get());
-  }
-
+  auto rewind(const std::uint64_t relative_offset, const std::uint64_t position)
+      -> std::uint64_t;
+  auto get_byte() -> std::uint8_t;
   // A "word" corresponds to two bytes
   // See https://stackoverflow.com/questions/28066462/how-many-bits-is-a-word
-  inline auto get_word() -> std::uint16_t {
-    std::uint16_t word;
-    this->stream.read(reinterpret_cast<char *>(&word), sizeof word);
-    return word;
-  }
-
-  inline auto get_varint() -> std::uint64_t {
-    return varint_decode(this->stream);
-  }
-
-  inline auto get_varint_zigzag() -> std::int64_t {
-    const std::uint64_t value = varint_decode(this->stream);
-    return zigzag_decode(value);
-  }
-
-  inline auto has_more_data() const noexcept -> bool {
-    // A way to check if the stream is empty without using `.peek()`,
-    // which throws given we set exceptions on the EOF bit.
-    // However, `in_avail()` works on characters and will return zero
-    // if all that's remaining is 0x00 (null), so we need to handle
-    // that case separately.
-    return this->stream.rdbuf()->in_avail() > 0 ||
-           this->stream.rdbuf()->sgetc() == '\0';
-  }
-
-  inline auto get_string_utf8(const std::uint64_t length)
-      -> sourcemeta::jsontoolkit::JSON::String {
-    sourcemeta::jsontoolkit::JSON::String result;
-    result.reserve(length);
-    std::uint64_t counter = 0;
-    while (counter < length) {
-      result +=
-          static_cast<sourcemeta::jsontoolkit::JSON::Char>(this->get_byte());
-      counter += 1;
-    }
-
-    assert(counter == length);
-    assert(result.size() == length);
-    return result;
-  }
+  auto get_word() -> std::uint16_t;
+  auto get_varint() -> std::uint64_t;
+  auto get_varint_zigzag() -> std::int64_t;
+  auto has_more_data() const noexcept -> bool;
+  auto get_string_utf8(const std::uint64_t length)
+      -> sourcemeta::jsontoolkit::JSON::String;
 
 private:
-  std::basic_istream<sourcemeta::jsontoolkit::JSON::Char,
-                     sourcemeta::jsontoolkit::JSON::CharTraits> &stream;
+  Stream &stream;
 };
 
 } // namespace sourcemeta::jsonbinpack
 
-#endif
 #endif

--- a/src/runtime/include/sourcemeta/jsonbinpack/runtime_output_stream.h
+++ b/src/runtime/include/sourcemeta/jsonbinpack/runtime_output_stream.h
@@ -1,81 +1,42 @@
 #ifndef SOURCEMETA_JSONBINPACK_RUNTIME_OUTPUT_STREAM_H_
 #define SOURCEMETA_JSONBINPACK_RUNTIME_OUTPUT_STREAM_H_
-#ifndef DOXYGEN
 
 #include "runtime_export.h"
 
-#include <sourcemeta/jsonbinpack/numeric.h>
 #include <sourcemeta/jsontoolkit/json.h>
 
 #include <sourcemeta/jsonbinpack/runtime_encoder_context.h>
-#include <sourcemeta/jsonbinpack/runtime_varint.h>
 
-#include <algorithm> // std::find_if
-#include <cassert>   // assert
-#include <cstdint>   // std::int8_t, std::uint8_t, std::int64_t
-#include <ios>       // std::ios_base
-#include <iterator>  // std::cbegin, std::cend, std::distance
-#include <ostream>   // std::basic_ostream
+#include <cstdint> // std::uint8_t, std::uint16_t, std::uint64_t
+#include <ostream> // std::basic_ostream
 
 namespace sourcemeta::jsonbinpack {
 
 /// @ingroup runtime
 class SOURCEMETA_JSONBINPACK_RUNTIME_EXPORT OutputStream {
 public:
-  OutputStream(
-      std::basic_ostream<sourcemeta::jsontoolkit::JSON::Char,
-                         sourcemeta::jsontoolkit::JSON::CharTraits> &output)
-      : stream{output} {
-    this->stream.exceptions(std::ios_base::badbit | std::ios_base::failbit |
-                            std::ios_base::eofbit);
-  }
+  using Stream = std::basic_ostream<sourcemeta::jsontoolkit::JSON::Char,
+                                    sourcemeta::jsontoolkit::JSON::CharTraits>;
+  OutputStream(Stream &output);
 
   // Prevent copying, as this class is tied to a stream resource
   OutputStream(const OutputStream &) = delete;
   auto operator=(const OutputStream &) -> OutputStream & = delete;
 
-  inline auto position() const noexcept -> std::uint64_t {
-    return static_cast<std::uint64_t>(this->stream.tellp());
-  }
-
-  inline auto put_byte(const std::uint8_t byte) -> void {
-    this->stream.put(static_cast<sourcemeta::jsontoolkit::JSON::Char>(byte));
-  }
-
-  inline auto put_bytes(const std::uint16_t bytes) -> void {
-    this->stream.write(
-        reinterpret_cast<const sourcemeta::jsontoolkit::JSON::Char *>(&bytes),
-        sizeof bytes);
-  }
-
-  inline auto put_varint(const std::uint64_t value) -> void {
-    varint_encode(this->stream, value);
-  }
-
-  inline auto put_varint_zigzag(const std::int64_t value) -> void {
-    varint_encode(this->stream, zigzag_encode(value));
-  }
-
-  inline auto
-  put_string_utf8(const sourcemeta::jsontoolkit::JSON::String &string,
-                  const std::uint64_t length) -> void {
-    assert(string.size() == length);
-    // Do a manual for-loop based on the provided length instead of a range
-    // loop based on the string value to avoid accidental overflows
-    for (std::uint64_t index = 0; index < length; index++) {
-      this->put_byte(static_cast<std::uint8_t>(string[index]));
-    }
-  }
-
-  inline auto context() -> Context & { return this->context_; }
+  auto position() const noexcept -> std::uint64_t;
+  auto put_byte(const std::uint8_t byte) -> void;
+  auto put_bytes(const std::uint16_t bytes) -> void;
+  auto put_varint(const std::uint64_t value) -> void;
+  auto put_varint_zigzag(const std::int64_t value) -> void;
+  auto put_string_utf8(const sourcemeta::jsontoolkit::JSON::String &string,
+                       const std::uint64_t length) -> void;
+  auto context() -> Context &;
 
 private:
-  std::basic_ostream<sourcemeta::jsontoolkit::JSON::Char,
-                     sourcemeta::jsontoolkit::JSON::CharTraits> &stream;
+  Stream &stream;
   Context context_;
 };
 
 } // namespace sourcemeta::jsonbinpack
 
-#endif
 #endif

--- a/src/runtime/input_stream.cc
+++ b/src/runtime/input_stream.cc
@@ -1,0 +1,78 @@
+#include <sourcemeta/jsonbinpack/numeric.h>
+#include <sourcemeta/jsonbinpack/runtime_input_stream.h>
+#include <sourcemeta/jsonbinpack/runtime_varint.h>
+
+#include <cassert> // assert
+#include <ios>     // std::ios_base
+
+namespace sourcemeta::jsonbinpack {
+
+InputStream::InputStream(Stream &input) : stream{input} {
+  this->stream.exceptions(std::ios_base::badbit | std::ios_base::failbit |
+                          std::ios_base::eofbit);
+}
+
+auto InputStream::position() const noexcept -> std::uint64_t {
+  return static_cast<std::uint64_t>(this->stream.tellg());
+}
+
+auto InputStream::seek(const std::uint64_t offset) -> void {
+  this->stream.seekg(static_cast<std::streamoff>(offset));
+}
+
+auto InputStream::rewind(const std::uint64_t relative_offset,
+                         const std::uint64_t position) -> std::uint64_t {
+  assert(position >= relative_offset);
+  const std::uint64_t offset{position - relative_offset};
+  assert(offset < position);
+  const std::uint64_t current{this->position()};
+  this->seek(offset);
+  return current;
+}
+
+auto InputStream::get_byte() -> std::uint8_t {
+  return static_cast<std::uint8_t>(this->stream.get());
+}
+
+auto InputStream::get_word() -> std::uint16_t {
+  std::uint16_t word;
+  this->stream.read(reinterpret_cast<char *>(&word), sizeof word);
+  return word;
+}
+
+auto InputStream::get_varint() -> std::uint64_t {
+  return varint_decode(this->stream);
+}
+
+auto InputStream::get_varint_zigzag() -> std::int64_t {
+  const std::uint64_t value = varint_decode(this->stream);
+  return zigzag_decode(value);
+}
+
+auto InputStream::has_more_data() const noexcept -> bool {
+  // A way to check if the stream is empty without using `.peek()`,
+  // which throws given we set exceptions on the EOF bit.
+  // However, `in_avail()` works on characters and will return zero
+  // if all that's remaining is 0x00 (null), so we need to handle
+  // that case separately.
+  return this->stream.rdbuf()->in_avail() > 0 ||
+         this->stream.rdbuf()->sgetc() == '\0';
+}
+
+auto InputStream::get_string_utf8(const std::uint64_t length)
+    -> sourcemeta::jsontoolkit::JSON::String {
+  sourcemeta::jsontoolkit::JSON::String result;
+  result.reserve(length);
+  std::uint64_t counter = 0;
+  while (counter < length) {
+    result +=
+        static_cast<sourcemeta::jsontoolkit::JSON::Char>(this->get_byte());
+    counter += 1;
+  }
+
+  assert(counter == length);
+  assert(result.size() == length);
+  return result;
+}
+
+} // namespace sourcemeta::jsonbinpack

--- a/src/runtime/output_stream.cc
+++ b/src/runtime/output_stream.cc
@@ -1,0 +1,50 @@
+#include <sourcemeta/jsonbinpack/numeric.h>
+#include <sourcemeta/jsonbinpack/runtime_output_stream.h>
+#include <sourcemeta/jsonbinpack/runtime_varint.h>
+
+#include <cassert> // assert
+#include <ios>     // std::ios_base
+
+namespace sourcemeta::jsonbinpack {
+
+OutputStream::OutputStream(Stream &output) : stream{output} {
+  this->stream.exceptions(std::ios_base::badbit | std::ios_base::failbit |
+                          std::ios_base::eofbit);
+}
+
+auto OutputStream::position() const noexcept -> std::uint64_t {
+  return static_cast<std::uint64_t>(this->stream.tellp());
+}
+
+auto OutputStream::put_byte(const std::uint8_t byte) -> void {
+  this->stream.put(static_cast<sourcemeta::jsontoolkit::JSON::Char>(byte));
+}
+
+auto OutputStream::put_bytes(const std::uint16_t bytes) -> void {
+  this->stream.write(
+      reinterpret_cast<const sourcemeta::jsontoolkit::JSON::Char *>(&bytes),
+      sizeof bytes);
+}
+
+auto OutputStream::put_varint(const std::uint64_t value) -> void {
+  varint_encode(this->stream, value);
+}
+
+auto OutputStream::put_varint_zigzag(const std::int64_t value) -> void {
+  varint_encode(this->stream, zigzag_encode(value));
+}
+
+auto OutputStream::put_string_utf8(
+    const sourcemeta::jsontoolkit::JSON::String &string,
+    const std::uint64_t length) -> void {
+  assert(string.size() == length);
+  // Do a manual for-loop based on the provided length instead of a range
+  // loop based on the string value to avoid accidental overflows
+  for (std::uint64_t index = 0; index < length; index++) {
+    this->put_byte(static_cast<std::uint8_t>(string[index]));
+  }
+}
+
+auto OutputStream::context() -> Context & { return this->context_; }
+
+} // namespace sourcemeta::jsonbinpack


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
