### PR TITLE
Put `Context` member in `Encoder` class

### DIFF
--- a/src/runtime/encoder_any.cc
+++ b/src/runtime/encoder_any.cc
@@ -108,7 +108,7 @@ auto Encoder::ANY_PACKED_TYPE_TAG_BYTE_PREFIX(
   } else if (document.is_string()) {
     const sourcemeta::jsontoolkit::JSON::String value{document.to_string()};
     const auto size{document.byte_size()};
-    const bool is_shared{this->context().has(value, Context::Type::Standalone)};
+    const bool is_shared{this->context_.has(value, Context::Type::Standalone)};
     if (size < uint_max<5>) {
       const std::uint8_t type{is_shared ? TYPE_SHARED_STRING : TYPE_STRING};
       this->put_byte(
@@ -116,10 +116,10 @@ auto Encoder::ANY_PACKED_TYPE_TAG_BYTE_PREFIX(
       if (is_shared) {
         this->put_varint(
             this->position() -
-            this->context().offset(value, Context::Type::Standalone));
+            this->context_.offset(value, Context::Type::Standalone));
       } else {
-        this->context().record(value, this->position(),
-                               Context::Type::Standalone);
+        this->context_.record(value, this->position(),
+                              Context::Type::Standalone);
         this->put_string_utf8(value, size);
       }
     } else if (size >= uint_max<5> && size < uint_max<5> * 2 && !is_shared) {

--- a/src/runtime/encoder_string.cc
+++ b/src/runtime/encoder_string.cc
@@ -21,7 +21,7 @@ auto Encoder::FLOOR_VARINT_PREFIX_UTF8_STRING_SHARED(
   const sourcemeta::jsontoolkit::JSON::String value{document.to_string()};
   const auto size{value.size()};
   assert(document.size() == size);
-  const bool is_shared{this->context().has(value, Context::Type::Standalone)};
+  const bool is_shared{this->context_.has(value, Context::Type::Standalone)};
 
   // (1) Write 0x00 if shared, else do nothing
   if (is_shared) {
@@ -34,9 +34,9 @@ auto Encoder::FLOOR_VARINT_PREFIX_UTF8_STRING_SHARED(
   // (3) Write relative offset if shared, else write plain string
   if (is_shared) {
     this->put_varint(this->position() -
-                     this->context().offset(value, Context::Type::Standalone));
+                     this->context_.offset(value, Context::Type::Standalone));
   } else {
-    this->context().record(value, this->position(), Context::Type::Standalone);
+    this->context_.record(value, this->position(), Context::Type::Standalone);
     this->put_string_utf8(value, size);
   }
 }
@@ -49,7 +49,7 @@ auto Encoder::ROOF_VARINT_PREFIX_UTF8_STRING_SHARED(
   const auto size{value.size()};
   assert(document.size() == size);
   assert(size <= options.maximum);
-  const bool is_shared{this->context().has(value, Context::Type::Standalone)};
+  const bool is_shared{this->context_.has(value, Context::Type::Standalone)};
 
   // (1) Write 0x00 if shared, else do nothing
   if (is_shared) {
@@ -62,9 +62,9 @@ auto Encoder::ROOF_VARINT_PREFIX_UTF8_STRING_SHARED(
   // (3) Write relative offset if shared, else write plain string
   if (is_shared) {
     this->put_varint(this->position() -
-                     this->context().offset(value, Context::Type::Standalone));
+                     this->context_.offset(value, Context::Type::Standalone));
   } else {
-    this->context().record(value, this->position(), Context::Type::Standalone);
+    this->context_.record(value, this->position(), Context::Type::Standalone);
     this->put_string_utf8(value, size);
   }
 }
@@ -79,7 +79,7 @@ auto Encoder::BOUNDED_8BIT_PREFIX_UTF8_STRING_SHARED(
   assert(options.minimum <= options.maximum);
   assert(is_byte(options.maximum - options.minimum + 1));
   assert(is_within(size, options.minimum, options.maximum));
-  const bool is_shared{this->context().has(value, Context::Type::Standalone)};
+  const bool is_shared{this->context_.has(value, Context::Type::Standalone)};
 
   // (1) Write 0x00 if shared, else do nothing
   if (is_shared) {
@@ -92,9 +92,9 @@ auto Encoder::BOUNDED_8BIT_PREFIX_UTF8_STRING_SHARED(
   // (3) Write relative offset if shared, else write plain string
   if (is_shared) {
     this->put_varint(this->position() -
-                     this->context().offset(value, Context::Type::Standalone));
+                     this->context_.offset(value, Context::Type::Standalone));
   } else {
-    this->context().record(value, this->position(), Context::Type::Standalone);
+    this->context_.record(value, this->position(), Context::Type::Standalone);
     this->put_string_utf8(value, size);
   }
 }
@@ -129,23 +129,23 @@ auto Encoder::PREFIX_VARINT_LENGTH_STRING_SHARED(
   assert(document.is_string());
   const sourcemeta::jsontoolkit::JSON::String value{document.to_string()};
 
-  if (this->context().has(value, Context::Type::PrefixLengthVarintPlusOne)) {
+  if (this->context_.has(value, Context::Type::PrefixLengthVarintPlusOne)) {
     const auto new_offset{this->position()};
     this->put_byte(0);
-    this->put_varint(this->position() -
-                     this->context().offset(
-                         value, Context::Type::PrefixLengthVarintPlusOne));
+    this->put_varint(
+        this->position() -
+        this->context_.offset(value, Context::Type::PrefixLengthVarintPlusOne));
     // Bump the context cache for locality purposes
-    this->context().record(value, new_offset,
-                           Context::Type::PrefixLengthVarintPlusOne);
+    this->context_.record(value, new_offset,
+                          Context::Type::PrefixLengthVarintPlusOne);
   } else {
     const auto size{value.size()};
     assert(document.size() == size);
-    this->context().record(value, this->position(),
-                           Context::Type::PrefixLengthVarintPlusOne);
+    this->context_.record(value, this->position(),
+                          Context::Type::PrefixLengthVarintPlusOne);
     this->put_varint(size + 1);
     // Also record a standalone variant of it
-    this->context().record(value, this->position(), Context::Type::Standalone);
+    this->context_.record(value, this->position(), Context::Type::Standalone);
     this->put_string_utf8(value, size);
   }
 }

--- a/src/runtime/include/sourcemeta/jsonbinpack/runtime_encoder.h
+++ b/src/runtime/include/sourcemeta/jsonbinpack/runtime_encoder.h
@@ -3,6 +3,7 @@
 
 #include "runtime_export.h"
 
+#include <sourcemeta/jsonbinpack/runtime_encoder_context.h>
 #include <sourcemeta/jsonbinpack/runtime_output_stream.h>
 #include <sourcemeta/jsonbinpack/runtime_plan.h>
 
@@ -63,6 +64,9 @@ public:
 
 #undef DECLARE_ENCODING
 #endif
+
+private:
+  Context context_;
 };
 
 } // namespace sourcemeta::jsonbinpack

--- a/src/runtime/include/sourcemeta/jsonbinpack/runtime_encoder_context.h
+++ b/src/runtime/include/sourcemeta/jsonbinpack/runtime_encoder_context.h
@@ -98,6 +98,7 @@ private:
 #if defined(_MSC_VER)
 #pragma warning(disable : 4251 4275)
 #endif
+  // TODO: Keep a reference to the string instead of copying it
   std::map<std::pair<sourcemeta::jsontoolkit::JSON::String, Type>,
            std::uint64_t>
       strings;

--- a/src/runtime/include/sourcemeta/jsonbinpack/runtime_output_stream.h
+++ b/src/runtime/include/sourcemeta/jsonbinpack/runtime_output_stream.h
@@ -5,8 +5,6 @@
 
 #include <sourcemeta/jsontoolkit/json.h>
 
-#include <sourcemeta/jsonbinpack/runtime_encoder_context.h>
-
 #include <cstdint> // std::uint8_t, std::uint16_t, std::uint64_t
 #include <ostream> // std::basic_ostream
 
@@ -30,11 +28,9 @@ public:
   auto put_varint_zigzag(const std::int64_t value) -> void;
   auto put_string_utf8(const sourcemeta::jsontoolkit::JSON::String &string,
                        const std::uint64_t length) -> void;
-  auto context() -> Context &;
 
 private:
   Stream &stream;
-  Context context_;
 };
 
 } // namespace sourcemeta::jsonbinpack

--- a/src/runtime/output_stream.cc
+++ b/src/runtime/output_stream.cc
@@ -46,6 +46,4 @@ auto OutputStream::put_string_utf8(
   }
 }
 
-auto OutputStream::context() -> Context & { return this->context_; }
-
 } // namespace sourcemeta::jsonbinpack


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
