### PR TITLE
Replace instances of `std::abort` with a custom `unreachable`

### DIFF
--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -10,6 +10,7 @@ noa_library(NAMESPACE sourcemeta PROJECT jsonbinpack NAME runtime
     input_stream.cc
     output_stream.cc
     varint.h
+    unreachable.h
 
     loader.cc
     loader_v1_any.h

--- a/src/runtime/decoder_any.cc
+++ b/src/runtime/decoder_any.cc
@@ -3,6 +3,8 @@
 
 #include <sourcemeta/jsonbinpack/runtime_plan_wrap.h>
 
+#include "unreachable.h"
+
 #include <cassert> // assert
 #include <cstdint> // std::uint8_t, std::uint16_t, std::uint64_t
 
@@ -84,8 +86,7 @@ auto Decoder::ANY_PACKED_TYPE_TAG_BYTE_PREFIX(
     }
 
     // We should never get here. If so, it is definitely a bug
-    assert(false);
-    std::abort();
+    unreachable();
   } else {
     switch (type) {
       case TYPE_POSITIVE_INTEGER_BYTE:
@@ -142,8 +143,7 @@ auto Decoder::ANY_PACKED_TYPE_TAG_BYTE_PREFIX(
     }
 
     // We should never get here. If so, it is definitely a bug
-    assert(false);
-    std::abort();
+    unreachable();
   }
 }
 

--- a/src/runtime/decoder_common.cc
+++ b/src/runtime/decoder_common.cc
@@ -1,7 +1,8 @@
 #include <sourcemeta/jsonbinpack/runtime_decoder.h>
 
+#include "unreachable.h"
+
 #include <cassert> // assert
-#include <cstdlib> // std::abort
 #include <variant> // std::get
 
 namespace sourcemeta::jsonbinpack {
@@ -39,8 +40,7 @@ auto Decoder::read(const Plan &encoding) -> sourcemeta::jsontoolkit::JSON {
   }
 
   // We should never get here. If so, it is definitely a bug
-  assert(false);
-  std::abort();
+  unreachable();
 }
 
 } // namespace sourcemeta::jsonbinpack

--- a/src/runtime/encoder_any.cc
+++ b/src/runtime/encoder_any.cc
@@ -2,6 +2,8 @@
 #include <sourcemeta/jsonbinpack/runtime_encoder.h>
 #include <sourcemeta/jsonbinpack/runtime_plan_wrap.h>
 
+#include "unreachable.h"
+
 #include <algorithm> // std::find_if
 #include <cassert>   // assert
 #include <cstdint>   // std::uint8_t, std::int64_t, std::uint64_t
@@ -177,9 +179,8 @@ auto Encoder::ANY_PACKED_TYPE_TAG_BYTE_PREFIX(
         document,
         {size, wrap(std::move(key_encoding)), wrap(std::move(value_encoding))});
   } else {
-    // We should never get here.
-    assert(false);
-    std::abort();
+    // We should never get here
+    unreachable();
   }
 }
 

--- a/src/runtime/encoder_common.cc
+++ b/src/runtime/encoder_common.cc
@@ -1,7 +1,8 @@
 #include <sourcemeta/jsonbinpack/runtime_encoder.h>
 
+#include "unreachable.h"
+
 #include <cassert> // assert
-#include <cstdlib> // std::abort
 #include <variant> // std::get
 
 namespace sourcemeta::jsonbinpack {
@@ -41,8 +42,7 @@ auto Encoder::write(const sourcemeta::jsontoolkit::JSON &document,
   }
 
   // We should never get here. If so, it is definitely a bug
-  assert(false);
-  std::abort();
+  unreachable();
 }
 
 } // namespace sourcemeta::jsonbinpack

--- a/src/runtime/unreachable.h
+++ b/src/runtime/unreachable.h
@@ -1,0 +1,17 @@
+#ifndef SOURCEMETA_JSONBINPACK_RUNTIME_UNREACHABLE_H_
+#define SOURCEMETA_JSONBINPACK_RUNTIME_UNREACHABLE_H_
+
+#include <cassert> // assert
+
+// Until we are on C++23 and can use std::unreachable
+// See https://en.cppreference.com/w/cpp/utility/unreachable
+[[noreturn]] inline void unreachable() {
+  assert(false);
+#if defined(_MSC_VER) && !defined(__clang__)
+  __assume(false);
+#else
+  __builtin_unreachable();
+#endif
+}
+
+#endif


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
